### PR TITLE
release 0.3.1

### DIFF
--- a/dataset_builders/pie/brat/requirements.txt
+++ b/dataset_builders/pie/brat/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0
+pie-datasets>=0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pie-datasets"
-version = "0.3.0"
+version = "0.3.1"
 description = "Building scripts for PyTorch-IE Datasets"
 authors = ["Arne Binder <arne.binder@dfki.de>"]
 readme = "README.md"


### PR DESCRIPTION
This also increases the minimum required `pie-datasets` version for the `brat` dataset script.