### PR TITLE
add `squad_v2` datasets

### DIFF
--- a/dataset_builders/pie/squad_v2/README.md
+++ b/dataset_builders/pie/squad_v2/README.md
@@ -15,9 +15,10 @@ The document type for this dataset is `SquadV2Document` which defines the follow
 and the following annotation layers:
 
 - `questions` (annotation type: `Question`, target: `None`)
-- `answers` (annotation type: `BinaryRelation`, targets: `text` and `questions`)
+- `answers` (annotation type: `ExtractiveAnswer`, targets: `text` and `questions`)
 
-See [here](https://github.com/ChristophAlt/pytorch-ie/blob/main/src/pytorch_ie/annotations.py) for the annotation type definitions.
+See [here](https://github.com/ArneBinder/pie-modules/blob/main/src/pie_modules/annotations.py) for the annotation
+type definitions.
 
 ## Document Converters
 
@@ -25,6 +26,5 @@ The dataset provides predefined document converters for the following target doc
 
 - `pie_modules.documents.ExtractiveQADocument` (simple cast without any conversion)
 
-See [here](https://github.com/ChristophAlt/pytorch-ie/blob/main/src/pytorch_ie/documents.py) and
-[here](https://github.com/ArneBinder/pie-modules/blob/main/src/pie_modules/documents.py) for the document type
+See [here](https://github.com/ArneBinder/pie-modules/blob/main/src/pie_modules/documents.py) for the document type
 definitions.

--- a/dataset_builders/pie/squad_v2/README.md
+++ b/dataset_builders/pie/squad_v2/README.md
@@ -1,0 +1,30 @@
+# PIE Dataset Card for "squad_v2"
+
+This is a [PyTorch-IE](https://github.com/ChristophAlt/pytorch-ie) wrapper for the
+[squad_v2 Huggingface dataset loading script](https://huggingface.co/datasets/squad_v2).
+
+## Data Schema
+
+The document type for this dataset is `SquadV2Document` which defines the following data fields:
+
+- `text` (str)
+- `id` (str, optional)
+- `metadata` (dictionary, optional)
+- `title` (str, optional)
+
+and the following annotation layers:
+
+- `questions` (annotation type: `Question`, target: `None`)
+- `answers` (annotation type: `BinaryRelation`, targets: `text` and `questions`)
+
+See [here](https://github.com/ChristophAlt/pytorch-ie/blob/main/src/pytorch_ie/annotations.py) for the annotation type definitions.
+
+## Document Converters
+
+The dataset provides predefined document converters for the following target document types:
+
+- `pie_modules.documents.ExtractiveQADocument` (simple cast without any conversion)
+
+See [here](https://github.com/ChristophAlt/pytorch-ie/blob/main/src/pytorch_ie/documents.py) and
+[here](https://github.com/ArneBinder/pie-modules/blob/main/src/pie_modules/documents.py) for the document type
+definitions.

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0
+pie-datasets>=0.3.3

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.3.3,<0.8.0
+pie-datasets>=0.7.1,<0.8.0
 pie-modules>=0.8.2,<0.9.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets>=0.3.3,<0.8.0
-# add when pie-modules including https://github.com/ArneBinder/pie-modules/pull/3 is released
-# pie-modules>=TODO,<TODO
+pie-modules>=0.8.2,<0.9.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.3,<0.5.0
+pie-datasets>=0.3.3,<0.8.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.3
+pie-datasets>=0.3.3,<0.5.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,0 +1,1 @@
+pie-datasets>=0.3.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,1 +1,3 @@
 pie-datasets>=0.3.3,<0.8.0
+# add when pie-modules including https://github.com/ArneBinder/pie-modules/pull/3 is released
+# pie-modules>=TODO,<TODO

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.7.1,<0.8.0
+pie-datasets>=0.8.0,<0.9.0
 pie-modules>=0.8.2,<0.9.0

--- a/dataset_builders/pie/squad_v2/squad_v2.py
+++ b/dataset_builders/pie/squad_v2/squad_v2.py
@@ -1,0 +1,118 @@
+import dataclasses
+from typing import Any, Dict, Optional
+
+import datasets
+from pytorch_ie.annotations import Span
+from pytorch_ie.core import Annotation, AnnotationList, annotation_field
+from pytorch_ie.documents import TextBasedDocument
+
+from pie_datasets import GeneratorBasedBuilder
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class Question(Annotation):
+    """A question about a context."""
+
+    text: str
+
+    def __str__(self) -> str:
+        return self.text
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class ExtractiveAnswer(Span):
+    """An answer to a question."""
+
+    # this annotation has two target fields
+    TARGET_NAMES = ("context", "questions")
+
+    question: Question
+
+    def __str__(self) -> str:
+        if not self.is_attached:
+            return ""
+        context = self.named_targets["context"]
+        return str(context[self.start : self.end])
+
+
+@dataclasses.dataclass
+class SquadV2Document(TextBasedDocument):
+    """A PIE document with annotations for SQuAD v2.0."""
+
+    title: Optional[str] = None
+    questions: AnnotationList[Question] = annotation_field()
+    answers: AnnotationList[ExtractiveAnswer] = annotation_field(
+        # The answers annotation layer depends on two other data fields / layers:
+        # The "text" data field (this is derived from TextBasedDocument) and the "questions" annotation layer.
+        # Any annotation layer with ExtractiveAnswer annotations expects the targets "context" and "questions".
+        # We provide the respective mapping as "named_targets".
+        named_targets={"context": "text", "questions": "questions"}
+    )
+
+
+def example_to_document(
+    example: Dict[str, Any],
+) -> SquadV2Document:
+    """Convert a Huggingface SQuAD v2.0 example to a PIE document."""
+    document = SquadV2Document(
+        id=example["id"],
+        title=example["title"],
+        text=example["context"],
+    )
+    question = Question(example["question"])
+    document.questions.append(question)
+    for answer_text, answer_start in zip(
+        example["answers"]["text"], example["answers"]["answer_start"]
+    ):
+        answer = ExtractiveAnswer(
+            question=question, start=answer_start, end=answer_start + len(answer_text)
+        )
+        document.answers.append(answer)
+    return document
+
+
+def document_to_example(doc: SquadV2Document) -> Dict[str, Any]:
+    """Convert a PIE document to a Huggingface SQuAD v2.0 example."""
+    example = {
+        "id": doc.id,
+        "title": doc.title,
+        "context": doc.text,
+        "question": doc.questions[0].text,
+        "answers": {
+            "text": [str(a) for a in doc.answers],
+            "answer_start": [a.start for a in doc.answers],
+        },
+    }
+    return example
+
+
+class SquadV2Config(datasets.BuilderConfig):
+    """BuilderConfig for SQuAD v2.0."""
+
+    def __init__(self, **kwargs):
+        """BuilderConfig for SQuAD v2.0.
+
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
+        super().__init__(**kwargs)
+
+
+class SquadV2(GeneratorBasedBuilder):
+    DOCUMENT_TYPE = SquadV2Document
+
+    BASE_DATASET_PATH = "squad_v2"
+    BASE_DATASET_REVISION = "e4d7191788b08fde3cbd09bd8fe1fcd827ee1715"
+
+    BUILDER_CONFIGS = [
+        SquadV2Config(
+            name="squad_v2",
+            version=datasets.Version("2.0.0"),
+            description="SQuAD plain text version 2",
+        ),
+    ]
+
+    DEFAULT_CONFIG_NAME = "squad_v2"  # type: ignore
+
+    def _generate_document(self, example):
+        return example_to_document(example)

--- a/dataset_builders/pie/squad_v2/squad_v2.py
+++ b/dataset_builders/pie/squad_v2/squad_v2.py
@@ -2,54 +2,17 @@ import dataclasses
 from typing import Any, Dict, Optional
 
 import datasets
-from pytorch_ie.annotations import Span
-from pytorch_ie.core import Annotation, AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument
+from pie_modules.annotations import ExtractiveAnswer, Question
+from pie_modules.documents import ExtractiveQADocument
 
 from pie_datasets import GeneratorBasedBuilder
 
 
-@dataclasses.dataclass(eq=True, frozen=True)
-class Question(Annotation):
-    """A question about a context."""
-
-    text: str
-
-    def __str__(self) -> str:
-        return self.text
-
-
-@dataclasses.dataclass(eq=True, frozen=True)
-class ExtractiveAnswer(Span):
-    """An answer to a question."""
-
-    # this annotation has two target fields
-    TARGET_NAMES = ("base", "questions")
-
-    question: Question
-    # The score of the answer. This is not considered when comparing two answers (e.g. prediction with gold).
-    score: Optional[float] = dataclasses.field(default=None, compare=False)
-
-    def __str__(self) -> str:
-        if not self.is_attached:
-            return ""
-        # we assume that the first target is the text
-        context = self.named_targets["base"]
-        return str(context[self.start : self.end])
-
-
 @dataclasses.dataclass
-class SquadV2Document(TextBasedDocument):
+class SquadV2Document(ExtractiveQADocument):
     """A PIE document with annotations for SQuAD v2.0."""
 
     title: Optional[str] = None
-    questions: AnnotationList[Question] = annotation_field()
-    # Note: We define the target fields / layers of the answers layer in the following way. Any answer
-    # targets the text field and (one entry of) the questions layer, so named_targets needs to contain
-    # these *values*. See ExtractiveAnswer.TARGET_NAMES for the required *keys* for named_targets.
-    answers: AnnotationList[ExtractiveAnswer] = annotation_field(
-        named_targets={"base": "text", "questions": "questions"}
-    )
 
 
 def example_to_document(
@@ -116,10 +79,9 @@ class SquadV2(GeneratorBasedBuilder):
 
     DEFAULT_CONFIG_NAME = "squad_v2"
 
-    # TODO: add when https://github.com/ArneBinder/pie-modules/pull/3 is merged
-    # DOCUMENT_CONVERTERS = {
-    #     ExtractiveQADocument: {},  # no conversion required, just cast to the correct type
-    # }
+    DOCUMENT_CONVERTERS = {
+        ExtractiveQADocument: {},  # no conversion required, just cast to the correct type
+    }
 
     def _generate_document(self, example, **kwargs):
         return example_to_document(example)

--- a/dataset_builders/pie/squad_v2/squad_v2.py
+++ b/dataset_builders/pie/squad_v2/squad_v2.py
@@ -85,3 +85,6 @@ class SquadV2(GeneratorBasedBuilder):
 
     def _generate_document(self, example, **kwargs):
         return example_to_document(example)
+
+    def _generate_example(self, document, **kwargs):
+        return document_to_example(document)

--- a/dataset_builders/pie/squad_v2/squad_v2.py
+++ b/dataset_builders/pie/squad_v2/squad_v2.py
@@ -112,7 +112,7 @@ class SquadV2(GeneratorBasedBuilder):
         ),
     ]
 
-    DEFAULT_CONFIG_NAME = "squad_v2"  # type: ignore
+    DEFAULT_CONFIG_NAME = "squad_v2"
 
     def _generate_document(self, example):
         return example_to_document(example)

--- a/dataset_builders/pie/squad_v2/squad_v2.py
+++ b/dataset_builders/pie/squad_v2/squad_v2.py
@@ -116,5 +116,10 @@ class SquadV2(GeneratorBasedBuilder):
 
     DEFAULT_CONFIG_NAME = "squad_v2"
 
+    # TODO: add when https://github.com/ArneBinder/pie-modules/pull/3 is merged
+    # DOCUMENT_CONVERTERS = {
+    #     ExtractiveQADocument: {},  # no conversion required, just cast to the correct type
+    # }
+
     def _generate_document(self, example, **kwargs):
         return example_to_document(example)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1028,13 +1028,13 @@ xml = ["lxml (>=4.8.0)"]
 
 [[package]]
 name = "pie-modules"
-version = "0.8.0"
+version = "0.8.2"
 description = "Model and Taskmodule implementations for PyTorch-IE"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "pie_modules-0.8.0-py3-none-any.whl", hash = "sha256:0b9cf500e98783b72475b7c30cc3050b7a23b848c480772d23537c19c7b374fa"},
-    {file = "pie_modules-0.8.0.tar.gz", hash = "sha256:b9c5f853ea3f8473a31268bf10b4c031f49216f43661666f3220d00bec333152"},
+    {file = "pie_modules-0.8.2-py3-none-any.whl", hash = "sha256:12e1cfdb73bbff390b92915f00315345d74779e629f92f6dac74dd90f87aa49a"},
+    {file = "pie_modules-0.8.2.tar.gz", hash = "sha256:34ad8de67b74cdebbb257e38eca83d09f5008f1d5c035a71372640234c6595bb"},
 ]
 
 [package.dependencies]
@@ -2077,4 +2077,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "93b59bbf5a490dfc89bd167023de4f4d0dad0798ffc171aeb1d8ab954f3b3b2c"
+content-hash = "0758cf80bb83748c8040f763262c921d65108f475a6d3d03383d212c2f24860f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ datasets = "^2.14"
 pyarrow = "^13"
 
 [tool.poetry.group.dev.dependencies]
-pie-modules = "^0.8"
+pie-modules = "^0.8.2"
 torch = {version = "^2.1.0+cpu", source = "pytorch"}
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"

--- a/tests/dataset_builders/pie/test_squad_v2.py
+++ b/tests/dataset_builders/pie/test_squad_v2.py
@@ -9,9 +9,7 @@ from dataset_builders.pie.squad_v2.squad_v2 import (
 )
 from pie_datasets import DatasetDict
 from tests import FIXTURES_ROOT
-from tests.dataset_builders.common import (
-    PIE_BASE_PATH,
-)
+from tests.dataset_builders.common import PIE_BASE_PATH
 
 disable_caching()
 

--- a/tests/dataset_builders/pie/test_squad_v2.py
+++ b/tests/dataset_builders/pie/test_squad_v2.py
@@ -1,16 +1,6 @@
-import dataclasses
-from typing import List
-
 import pytest
 from datasets import disable_caching, load_dataset
-from pie_modules.document.processing import tokenize_document
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, Document, annotation_field
-from pytorch_ie.documents import (
-    TextBasedDocument,
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-)
-from transformers import AutoTokenizer, PreTrainedTokenizer
+from pytorch_ie.core import Document
 
 from dataset_builders.pie.squad_v2.squad_v2 import (
     SquadV2,
@@ -21,8 +11,6 @@ from pie_datasets import DatasetDict
 from tests import FIXTURES_ROOT
 from tests.dataset_builders.common import (
     PIE_BASE_PATH,
-    TestTokenDocumentWithLabeledSpansAndBinaryRelations,
-    _deep_compare,
 )
 
 disable_caching()

--- a/tests/dataset_builders/pie/test_squad_v2.py
+++ b/tests/dataset_builders/pie/test_squad_v2.py
@@ -9,7 +9,6 @@ from dataset_builders.pie.squad_v2.squad_v2 import (
     example_to_document,
 )
 from pie_datasets import DatasetDict
-from tests import FIXTURES_ROOT
 from tests.dataset_builders.common import PIE_BASE_PATH
 
 disable_caching()
@@ -20,7 +19,6 @@ DOCUMENT_TYPE = SquadV2.DOCUMENT_TYPE
 SPLIT_SIZES = {"train": 130319, "validation": 11873}
 HF_DATASET_PATH = BUILDER_CLASS.BASE_DATASET_PATH
 PIE_DATASET_PATH = PIE_BASE_PATH / DATASET_NAME
-DATA_PATH = FIXTURES_ROOT / "dataset_builders" / "squad_v2.zip"
 
 
 @pytest.fixture(scope="module", params=list(SPLIT_SIZES))
@@ -30,7 +28,7 @@ def split(request):
 
 @pytest.fixture(scope="module")
 def hf_dataset():
-    return load_dataset(str(HF_DATASET_PATH), data_dir=DATA_PATH)
+    return load_dataset(str(HF_DATASET_PATH))
 
 
 def test_hf_dataset(hf_dataset):

--- a/tests/dataset_builders/pie/test_squad_v2.py
+++ b/tests/dataset_builders/pie/test_squad_v2.py
@@ -1,0 +1,182 @@
+import dataclasses
+from typing import List
+
+import pytest
+from datasets import disable_caching, load_dataset
+from pie_modules.document.processing import tokenize_document
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+)
+from transformers import AutoTokenizer, PreTrainedTokenizer
+
+from dataset_builders.pie.squad_v2.squad_v2 import (
+    SquadV2,
+    document_to_example,
+    example_to_document,
+)
+from pie_datasets import DatasetDict
+from tests import FIXTURES_ROOT
+from tests.dataset_builders.common import (
+    PIE_BASE_PATH,
+    TestTokenDocumentWithLabeledSpansAndBinaryRelations,
+    _deep_compare,
+)
+
+disable_caching()
+
+DATASET_NAME = "squad_v2"
+BUILDER_CLASS = SquadV2
+DOCUMENT_TYPE = SquadV2.DOCUMENT_TYPE
+SPLIT_SIZES = {"train": 130319, "validation": 11873}
+HF_DATASET_PATH = BUILDER_CLASS.BASE_DATASET_PATH
+PIE_DATASET_PATH = PIE_BASE_PATH / DATASET_NAME
+DATA_PATH = FIXTURES_ROOT / "dataset_builders" / "squad_v2.zip"
+
+
+@pytest.fixture(scope="module", params=list(SPLIT_SIZES))
+def split(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def hf_dataset():
+    return load_dataset(str(HF_DATASET_PATH), data_dir=DATA_PATH)
+
+
+def test_hf_dataset(hf_dataset):
+    assert hf_dataset is not None
+    assert {name: len(ds) for name, ds in hf_dataset.items()} == SPLIT_SIZES
+
+
+@pytest.fixture(scope="module")
+def hf_example(hf_dataset, split):
+    return hf_dataset[split][0]
+
+
+def test_hf_example(hf_example, split):
+    assert hf_example is not None
+    if split == "train":
+        assert hf_example == {
+            "id": "56be85543aeaaa14008c9063",
+            "title": "Beyoncé",
+            "context": "Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981) is an "
+            "American singer, songwriter, record producer and actress. Born and raised in Houston, "
+            "Texas, she performed in various singing and dancing competitions as a child, and rose to "
+            "fame in the late 1990s as lead singer of R&B girl-group Destiny's Child. Managed by her "
+            "father, Mathew Knowles, the group became one of the world's best-selling girl groups of "
+            "all time. Their hiatus saw the release of Beyoncé's debut album, Dangerously in Love "
+            "(2003), which established her as a solo artist worldwide, earned five Grammy Awards and "
+            'featured the Billboard Hot 100 number-one singles "Crazy in Love" and "Baby Boy".',
+            "question": "When did Beyonce start becoming popular?",
+            "answers": {"text": ["in the late 1990s"], "answer_start": [269]},
+        }
+    elif split == "validation":
+        assert hf_example == {
+            "id": "56ddde6b9a695914005b9628",
+            "title": "Normans",
+            "context": "The Normans (Norman: Nourmands; French: Normands; Latin: Normanni) were the people who in "
+            "the 10th and 11th centuries gave their name to Normandy, a region in France. They were "
+            'descended from Norse ("Norman" comes from "Norseman") raiders and pirates from Denmark, '
+            "Iceland and Norway who, under their leader Rollo, agreed to swear fealty to King Charles "
+            "III of West Francia. Through generations of assimilation and mixing with the native "
+            "Frankish and Roman-Gaulish populations, their descendants would gradually merge with the "
+            "Carolingian-based cultures of West Francia. The distinct cultural and ethnic identity of "
+            "the Normans emerged initially in the first half of the 10th century, and it continued to "
+            "evolve over the succeeding centuries.",
+            "question": "In what country is Normandy located?",
+            "answers": {
+                "text": ["France", "France", "France", "France"],
+                "answer_start": [159, 159, 159, 159],
+            },
+        }
+    else:
+        raise ValueError(f"Unknown split: {split}")
+
+
+@pytest.fixture(scope="module")
+def generate_document_kwargs(hf_dataset, split) -> dict:
+    return BUILDER_CLASS()._generate_document_kwargs(hf_dataset[split]) or {}
+
+
+@pytest.fixture(scope="module")
+def generated_document(hf_example, generate_document_kwargs) -> DOCUMENT_TYPE:
+    return BUILDER_CLASS()._generate_document(hf_example, **generate_document_kwargs)
+
+
+def test_generated_document(generated_document, split):
+    assert isinstance(generated_document, DOCUMENT_TYPE)
+    if split == "train":
+        assert generated_document.id == "56be85543aeaaa14008c9063"
+        assert generated_document.title == "Beyoncé"
+        assert generated_document.text.startswith(
+            "Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981)"
+        )
+        assert len(generated_document.questions) == 1
+        assert str(generated_document.questions[0]) == "When did Beyonce start becoming popular?"
+
+        assert len(generated_document.answers) == 1
+        assert str(generated_document.answers[0]) == "in the late 1990s"
+
+    elif split == "validation":
+        assert generated_document.id == "56ddde6b9a695914005b9628"
+        assert generated_document.title == "Normans"
+        assert generated_document.text.startswith(
+            "The Normans (Norman: Nourmands; French: Normands; Latin: Normanni) were the people who in the "
+            "10th and 11th centuries gave their name to Normandy, a region in France."
+        )
+        assert len(generated_document.questions) == 1
+        assert str(generated_document.questions[0]) == "In what country is Normandy located?"
+
+        assert len(generated_document.answers) == 4
+        assert str(generated_document.answers[0]) == "France"
+        assert str(generated_document.answers[1]) == "France"
+        assert str(generated_document.answers[2]) == "France"
+        assert str(generated_document.answers[3]) == "France"
+
+    else:
+        raise ValueError(f"Unknown split: {split}")
+
+
+@pytest.fixture(scope="module")
+def hf_example_back(generated_document, generate_document_kwargs):
+    return document_to_example(generated_document, **generate_document_kwargs)
+
+
+def test_example_to_document_and_back(hf_example, hf_example_back):
+    assert hf_example_back == hf_example
+
+
+@pytest.mark.slow
+def test_example_to_document_and_back_all(hf_dataset, generate_document_kwargs, split):
+    for hf_ex in hf_dataset[split]:
+        doc = example_to_document(hf_ex, **generate_document_kwargs)
+        hf_ex_back = document_to_example(doc, **generate_document_kwargs)
+        assert hf_ex_back == hf_ex
+
+
+@pytest.fixture(scope="module")
+def dataset() -> DatasetDict:
+    return DatasetDict.load_dataset(str(PIE_DATASET_PATH))
+
+
+def test_pie_dataset(dataset):
+    assert dataset is not None
+    assert {name: len(ds) for name, ds in dataset.items()} == SPLIT_SIZES
+
+
+@pytest.fixture(scope="module")
+def document(dataset, split) -> DOCUMENT_TYPE:
+    doc = dataset[split][0]
+    # we can not assert the real document type because it may come from a dataset loading script
+    # downloaded to a temporary directory and thus have a different type object, although it is
+    # semantically the same
+    assert isinstance(doc, Document)
+    casted = doc.as_type(DOCUMENT_TYPE)
+    return casted
+
+
+def test_compare_document_and_generated_document(document, generated_document):
+    assert document == generated_document

--- a/tests/dataset_builders/pie/test_squad_v2.py
+++ b/tests/dataset_builders/pie/test_squad_v2.py
@@ -1,5 +1,6 @@
 import pytest
 from datasets import disable_caching, load_dataset
+from pie_modules.documents import ExtractiveQADocument
 from pytorch_ie.core import Document
 
 from dataset_builders.pie.squad_v2.squad_v2 import (
@@ -166,3 +167,18 @@ def document(dataset, split) -> DOCUMENT_TYPE:
 
 def test_compare_document_and_generated_document(document, generated_document):
     assert document == generated_document
+
+
+@pytest.fixture(scope="module")
+def dataset_with_extractive_qa_documents(dataset) -> DatasetDict:
+    return dataset.to_document_type(ExtractiveQADocument)
+
+
+def test_dataset_with_extractive_qa_documents(
+    dataset_with_extractive_qa_documents, document, split
+):
+    assert dataset_with_extractive_qa_documents is not None
+    doc = dataset_with_extractive_qa_documents[split][0]
+    assert isinstance(doc, ExtractiveQADocument)
+    doc_casted = document.as_type(ExtractiveQADocument)
+    assert doc == doc_casted


### PR DESCRIPTION
This adds the `squad_v2` dataset, see [here](https://huggingface.co/datasets/squad_v2) for the Huggingface dataset card.

TODO:
 - [x] add a dataset card, i.e. `README.md`
 - ~[ ] use tests with just a dataset extract, mark other tests with `@pytest.mark.slow`~ the HF dataset script does nto allow to set a `data_dir`
 - [x] add document converters when new `pie-modules` including https://github.com/ArneBinder/pie-modules/pull/3 is released
 - [x] add tests
   - [x] hf dataset sizes and instance
   - [x] hf -> doc -> hf
   - [x] pie dataset sizes and instance
   - [x] converters