### PR TITLE
fix `pie-datasets` version ranges in dataset loading scripts

### DIFF
--- a/dataset_builders/pie/brat/requirements.txt
+++ b/dataset_builders/pie/brat/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.1
+pie-datasets>=0.4.0,<0.5.0

--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0,<0.5.0
+pie-datasets>=0.3.3,<0.5.0

--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0
+pie-datasets>=0.3.0,<0.5.0

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0,<0.5.0
+pie-datasets>=0.3.3,<0.5.0

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0
+pie-datasets>=0.3.0,<0.5.0

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,2 +1,1 @@
-pie-datasets>=0.3.3
-pytorch-ie>=0.29.1
+pie-datasets>=0.4.0,<0.5.0

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0,<0.5.0
+pie-datasets>=0.3.3,<0.5.0

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0
+pie-datasets>=0.3.0,<0.5.0


### PR DESCRIPTION
This sets max versions for `pie-datasets` in the dataset loading scripts to avoid any breaking in the future . It also fixes #55.