### PR TITLE
make `pie-modules` a dev dependency

### DIFF
--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,1 +1,2 @@
 pie-datasets>=0.6.0,<0.7.0
+pie-modules>=0.8.0,<0.9.0

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,1 +1,2 @@
 pie-datasets>=0.6.0,<0.7.0
+pie-modules>=0.8.0,<0.9.0

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,1 +1,2 @@
 pie-datasets>=0.6.0,<0.7.0
+pie-modules>=0.8.0,<0.9.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -2077,4 +2077,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4aa02150b3df55a4eedb1b1d95a0bbdd4cfb765b3467a8b30f21322df89bdeee"
+content-hash = "93b59bbf5a490dfc89bd167023de4f4d0dad0798ffc171aeb1d8ab954f3b3b2c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,13 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pie-modules = "^0.8.0"
+pytorch-ie = "^0.29.2"
 datasets = "^2.14"
 # this was manually added because we get a conflict with pyarrow otherwise
 pyarrow = "^13"
 
 [tool.poetry.group.dev.dependencies]
+pie-modules = "^0.8"
 torch = {version = "^2.1.0+cpu", source = "pytorch"}
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"


### PR DESCRIPTION
This PR makes `pie-modules` a dev dependency and adds it to the respective dataset script requirements.