### PR TITLE
Fix brat revisions

### DIFF
--- a/dataset_builders/pie/brat/brat.py
+++ b/dataset_builders/pie/brat/brat.py
@@ -3,4 +3,4 @@ from pie_datasets.builders import BratBuilder
 
 class Brat(BratBuilder):
     BASE_DATASET_PATH = "DFKI-SLT/brat"
-    BASE_DATASET_REVISION = "052163d34b4429d81003981bc10674cef54aa0b8"
+    BASE_DATASET_REVISION = "844de61e8a00dc6a93fc29dc185f6e617131fbf1"

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -297,7 +297,9 @@ class BratBuilder(GeneratorBasedBuilder):
     ]
 
     BASE_DATASET_PATH = "DFKI-SLT/brat"
-    BASE_DATASET_REVISION = "70446e79e089d5e5cd5f3426061991a2fcfbf529"
+    BASE_DATASET_REVISION = (
+        None  # it is highly recommended to set this to a commit hash in any derived builder
+    )
 
     def _generate_document(self, example, **kwargs):
         return example_to_document(


### PR DESCRIPTION
This PR implements #84. We update the revision for the `Brat` builder to the version with the encoding fix for windows (https://huggingface.co/datasets/DFKI-SLT/brat/commit/844de61e8a00dc6a93fc29dc185f6e617131fbf1).

This is **breaking** because we set the `BASE_DATASET_REVISION` for the generic `BratBuilder` back to `None` (this should just be set in derived builders).