### PR TITLE
add `_generate_example()` and `_generate_example_kwargs()` to `PieDatasetBuilder`

### DIFF
--- a/src/pie_datasets/core/builder.py
+++ b/src/pie_datasets/core/builder.py
@@ -173,7 +173,7 @@ class PieDatasetBuilder(datasets.builder.DatasetBuilder):
     def _generate_example_kwargs(
         self, dataset: Union[Dataset, IterableDataset]
     ) -> Optional[Dict[str, Any]]:
-        return None
+        return None  # pragma: no cover
 
     @overload  # type: ignore
     def _convert_dataset_single(self, dataset: datasets.IterableDataset) -> IterableDataset:

--- a/src/pie_datasets/core/builder.py
+++ b/src/pie_datasets/core/builder.py
@@ -167,6 +167,14 @@ class PieDatasetBuilder(datasets.builder.DatasetBuilder):
     def _generate_document_kwargs(self, dataset):
         return None
 
+    def _generate_example(self, document: Document, **kwargs) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def _generate_example_kwargs(
+        self, dataset: Union[Dataset, IterableDataset]
+    ) -> Optional[Dict[str, Any]]:
+        return None
+
     @overload  # type: ignore
     def _convert_dataset_single(self, dataset: datasets.IterableDataset) -> IterableDataset:
         ...


### PR DESCRIPTION
For now, these methods are not effectively used. But they will serve as a common interface for back conversion to Huggingface dataset instances.