### PR TITLE
fix sciarg tests: tokenization with partitions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1028,18 +1028,18 @@ xml = ["lxml (>=4.8.0)"]
 
 [[package]]
 name = "pie-modules"
-version = "0.8.2"
+version = "0.8.3"
 description = "Model and Taskmodule implementations for PyTorch-IE"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "pie_modules-0.8.2-py3-none-any.whl", hash = "sha256:12e1cfdb73bbff390b92915f00315345d74779e629f92f6dac74dd90f87aa49a"},
-    {file = "pie_modules-0.8.2.tar.gz", hash = "sha256:34ad8de67b74cdebbb257e38eca83d09f5008f1d5c035a71372640234c6595bb"},
+    {file = "pie_modules-0.8.3-py3-none-any.whl", hash = "sha256:4a161b0160925b919a37880f24dbd696de40ce58ad5a06ab2064a227862c0823"},
+    {file = "pie_modules-0.8.3.tar.gz", hash = "sha256:5f434d0dca1d44fa2a13460339f2ae0c95a6461ef952fcdf4c1545aaf4beb278"},
 ]
 
 [package.dependencies]
 pytorch-crf = ">=0.7.2"
-pytorch-ie = ">=0.29.2,<0.30.0"
+pytorch-ie = ">=0.29.4,<0.30.0"
 torchmetrics = ">=1,<2"
 
 [[package]]
@@ -1198,13 +1198,13 @@ files = [
 
 [[package]]
 name = "pytorch-ie"
-version = "0.29.2"
+version = "0.29.4"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "pytorch_ie-0.29.2-py3-none-any.whl", hash = "sha256:73908f8a6b43e9484a8a463ce601e50367fbdca9e7be44d83608b1f035502bb1"},
-    {file = "pytorch_ie-0.29.2.tar.gz", hash = "sha256:9c0b43b43307107c963e927336a0083a7f4fa4ca224b1447999848eedddde0d7"},
+    {file = "pytorch_ie-0.29.4-py3-none-any.whl", hash = "sha256:40117d4d17866088cd50f18e9abc5ccf7b4c7e1599c54b7de4fdcbb601e01c11"},
+    {file = "pytorch_ie-0.29.4.tar.gz", hash = "sha256:903a82ff6701a583a587c00420907a0d8af6fe5de56ae3de1111344cad00fc1b"},
 ]
 
 [package.dependencies]
@@ -2077,4 +2077,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0758cf80bb83748c8040f763262c921d65108f475a6d3d03383d212c2f24860f"
+content-hash = "2cfe46b464d380a8e3179fa8b7f10cd1cc4bfe98791e290644ce9e309683bafa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ datasets = "^2.14"
 pyarrow = "^13"
 
 [tool.poetry.group.dev.dependencies]
-pie-modules = "^0.8.2"
+pie-modules = "^0.8.3"
 torch = {version = "^2.1.0+cpu", source = "pytorch"}
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"

--- a/tests/dataset_builders/pie/test_sciarg.py
+++ b/tests/dataset_builders/pie/test_sciarg.py
@@ -363,7 +363,6 @@ def tokenized_documents_with_labeled_spans_and_binary_relations(
         tokenizer=tokenizer,
         return_overflowing_tokens=True,
         result_document_type=TestTokenDocumentWithLabeledSpansAndBinaryRelations,
-        strict_span_conversion=False,
         verbose=True,
     )
     return tokenized_docs
@@ -433,7 +432,6 @@ def test_tokenized_documents_with_entities_and_relations_all(
                     tokenizer=tokenizer,
                     return_overflowing_tokens=True,
                     result_document_type=TestTokenDocumentWithLabeledSpansAndBinaryRelations,
-                    strict_span_conversion=False,
                     verbose=True,
                 )
                 # we just ensure that we get at least one tokenized document
@@ -458,6 +456,7 @@ def tokenized_documents_with_labeled_spans_binary_relations_and_labeled_partitio
         tokenized_docs = tokenize_document(
             doc,
             tokenizer=tokenizer,
+            partition_layer="labeled_partitions",
             return_overflowing_tokens=True,
             result_document_type=TestTokenDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
             strict_span_conversion=False,
@@ -474,16 +473,76 @@ def test_tokenized_documents_with_labeled_spans_binary_relations_and_labeled_par
         docs_with_partitions = (
             tokenized_documents_with_labeled_spans_binary_relations_and_labeled_partitions
         )
-        docs_without_partitions = tokenized_documents_with_labeled_spans_and_binary_relations
 
         # check that the tokenization was fine
-        assert len(docs_with_partitions) == 1
+        assert len(docs_with_partitions) == 10
         doc_with_partitions = docs_with_partitions[0]
-        doc_without_partitions = docs_without_partitions[0]
-        assert len(doc_with_partitions.labeled_partitions) == 10
-        assert doc_with_partitions.labeled_spans == doc_without_partitions.labeled_spans
-        assert doc_with_partitions.binary_relations == doc_without_partitions.binary_relations
-        assert doc_with_partitions.tokens == doc_without_partitions.tokens
+        assert len(doc_with_partitions.labeled_partitions) == 1
+        assert len(doc_with_partitions.labeled_spans) == 0
+        assert len(doc_with_partitions.binary_relations) == 0
+        assert doc_with_partitions.tokens == (
+            "[CLS]",
+            "<",
+            "title",
+            ">",
+            "a",
+            "powell",
+            "optimization",
+            "approach",
+            "for",
+            "example",
+            "-",
+            "based",
+            "skin",
+            "##ning",
+            "in",
+            "a",
+            "production",
+            "animation",
+            "environment",
+            "<",
+            "/",
+            "title",
+            ">",
+            "xiao",
+            "xi",
+            "##an",
+            "∗",
+            "john",
+            "p",
+            ".",
+            "lewis",
+            "nan",
+            "##yang",
+            "technological",
+            "university",
+            "graphic",
+            "primitive",
+            "##s",
+            "sea",
+            "##h",
+            "hoc",
+            "##k",
+            "soon",
+            "nick",
+            "##son",
+            "f",
+            "##ong",
+            "nan",
+            "##yang",
+            "technological",
+            "university",
+            "eggs",
+            "##tory",
+            "##cp",
+            "tian",
+            "feng",
+            "nan",
+            "##yang",
+            "technological",
+            "university",
+            "[SEP]",
+        )
 
 
 def test_tokenized_documents_with_entities_relations_and_partitions_all(
@@ -505,6 +564,7 @@ def test_tokenized_documents_with_entities_relations_and_partitions_all(
                 tokenized_docs = tokenize_document(
                     doc,
                     tokenizer=tokenizer,
+                    partition_layer="labeled_partitions",
                     return_overflowing_tokens=True,
                     result_document_type=TestTokenDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
                     strict_span_conversion=False,
@@ -513,6 +573,9 @@ def test_tokenized_documents_with_entities_relations_and_partitions_all(
                 # we just ensure that we get at least one tokenized document
                 assert tokenized_docs is not None
                 assert len(tokenized_docs) > 0
+                for tokenized_doc in tokenized_docs:
+                    assert tokenized_doc.labeled_partitions is not None
+                    assert len(tokenized_doc.labeled_partitions) == 1
 
 
 def test_document_converters(dataset_variant):


### PR DESCRIPTION
Before this PR, the partition annotations were not used at all for the tokenization in the tests with docuements that have partitions.