### PR TITLE
`cdcp` dataset: use fixed HF dataset

### DIFF
--- a/dataset_builders/pie/cdcp/cdcp.py
+++ b/dataset_builders/pie/cdcp/cdcp.py
@@ -125,7 +125,7 @@ class CDCP(GeneratorBasedBuilder):
     }
 
     BASE_DATASET_PATH = "DFKI-SLT/cdcp"
-    BASE_DATASET_REVISION = "45cf7a6d89866caa8a21c40edf335b88a725ecdb"
+    BASE_DATASET_REVISION = "3cf79257900b3f97e4b8f9faae2484b1a534f484"
 
     BUILDER_CONFIGS = [datasets.BuilderConfig(name="default")]
 

--- a/tests/dataset_builders/pie/test_cdcp.py
+++ b/tests/dataset_builders/pie/test_cdcp.py
@@ -31,8 +31,9 @@ disable_caching()
 
 DATASET_NAME = "cdcp"
 BUILDER_CLASS = CDCP
-SPLIT_SIZES = {"train": 581, "test": 150}
+SPLIT_SIZES = {"train": 580, "test": 150}
 HF_DATASET_PATH = CDCP.BASE_DATASET_PATH
+HF_DATASET_REVISION = CDCP.BASE_DATASET_REVISION
 PIE_DATASET_PATH = PIE_BASE_PATH / DATASET_NAME
 DATA_PATH = FIXTURES_ROOT / "dataset_builders" / "cdcp_acl17.zip"
 
@@ -77,7 +78,7 @@ def split(request):
 
 @pytest.fixture(scope="module")
 def hf_dataset():
-    return load_dataset(str(HF_DATASET_PATH), data_dir=DATA_PATH)
+    return load_dataset(str(HF_DATASET_PATH), data_dir=DATA_PATH, revision=HF_DATASET_REVISION)
 
 
 def test_hf_dataset(hf_dataset):


### PR DESCRIPTION
This PR updates the revision of the `cdcp` base dataset to [3cf79257900b3f97e4b8f9faae2484b1a534f484](https://huggingface.co/datasets/DFKI-SLT/cdcp/commit/3cf79257900b3f97e4b8f9faae2484b1a534f484), i.e. the broken example (id=00410) is skipped. This fixes #98.