### PR TITLE
decrease `squad_v2` test time

### DIFF
--- a/tests/dataset_builders/pie/test_squad_v2.py
+++ b/tests/dataset_builders/pie/test_squad_v2.py
@@ -4,7 +4,7 @@ from pie_modules.documents import ExtractiveQADocument
 from pytorch_ie.core import Document
 
 from dataset_builders.pie.squad_v2.squad_v2 import SquadV2
-from pie_datasets import Dataset, load_dataset
+from pie_datasets import Dataset, IterableDataset, load_dataset
 from tests.dataset_builders.common import PIE_BASE_PATH
 
 datasets.disable_caching()
@@ -16,7 +16,7 @@ SPLIT_SIZES = {"train": 130319, "validation": 11873}
 HF_DATASET_PATH = BUILDER_CLASS.BASE_DATASET_PATH
 PIE_DATASET_PATH = PIE_BASE_PATH / DATASET_NAME
 
-# Faste testing parameters TODO: use them
+# fast testing parameters
 SPLIT = "train"
 STREAM_SIZE = 3
 
@@ -31,102 +31,69 @@ def hf_dataset(split):
     return datasets.load_dataset(str(HF_DATASET_PATH), split=split)
 
 
+@pytest.mark.slow
 def test_hf_dataset(hf_dataset, split):
     assert hf_dataset is not None
     assert len(hf_dataset) == SPLIT_SIZES[split]
 
 
 @pytest.fixture(scope="module")
-def hf_example(hf_dataset):
-    return hf_dataset[0]
+def hf_dataset_fast() -> datasets.IterableDataset:
+    return datasets.load_dataset(str(HF_DATASET_PATH), split=SPLIT, streaming=True).take(
+        STREAM_SIZE
+    )
 
 
-def test_hf_example(hf_example, split):
-    assert hf_example is not None
-    if split == "train":
-        assert hf_example == {
-            "id": "56be85543aeaaa14008c9063",
-            "title": "Beyoncé",
-            "context": "Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981) is an "
-            "American singer, songwriter, record producer and actress. Born and raised in Houston, "
-            "Texas, she performed in various singing and dancing competitions as a child, and rose to "
-            "fame in the late 1990s as lead singer of R&B girl-group Destiny's Child. Managed by her "
-            "father, Mathew Knowles, the group became one of the world's best-selling girl groups of "
-            "all time. Their hiatus saw the release of Beyoncé's debut album, Dangerously in Love "
-            "(2003), which established her as a solo artist worldwide, earned five Grammy Awards and "
-            'featured the Billboard Hot 100 number-one singles "Crazy in Love" and "Baby Boy".',
-            "question": "When did Beyonce start becoming popular?",
-            "answers": {"text": ["in the late 1990s"], "answer_start": [269]},
-        }
-    elif split == "validation":
-        assert hf_example == {
-            "id": "56ddde6b9a695914005b9628",
-            "title": "Normans",
-            "context": "The Normans (Norman: Nourmands; French: Normands; Latin: Normanni) were the people who in "
-            "the 10th and 11th centuries gave their name to Normandy, a region in France. They were "
-            'descended from Norse ("Norman" comes from "Norseman") raiders and pirates from Denmark, '
-            "Iceland and Norway who, under their leader Rollo, agreed to swear fealty to King Charles "
-            "III of West Francia. Through generations of assimilation and mixing with the native "
-            "Frankish and Roman-Gaulish populations, their descendants would gradually merge with the "
-            "Carolingian-based cultures of West Francia. The distinct cultural and ethnic identity of "
-            "the Normans emerged initially in the first half of the 10th century, and it continued to "
-            "evolve over the succeeding centuries.",
-            "question": "In what country is Normandy located?",
-            "answers": {
-                "text": ["France", "France", "France", "France"],
-                "answer_start": [159, 159, 159, 159],
-            },
-        }
-    else:
-        raise ValueError(f"Unknown split: {split}")
+def test_hf_dataset_fast(hf_dataset_fast):
+    assert hf_dataset_fast is not None
 
 
 @pytest.fixture(scope="module")
-def generated_document(hf_example) -> DOCUMENT_TYPE:
-    return BUILDER_CLASS()._generate_document(hf_example)
+def hf_example_fast(hf_dataset_fast):
+    return list(hf_dataset_fast)[0]
 
 
-def test_generated_document(generated_document, split):
-    assert isinstance(generated_document, DOCUMENT_TYPE)
-    if split == "train":
-        assert generated_document.id == "56be85543aeaaa14008c9063"
-        assert generated_document.title == "Beyoncé"
-        assert generated_document.text.startswith(
-            "Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981)"
-        )
-        assert len(generated_document.questions) == 1
-        assert str(generated_document.questions[0]) == "When did Beyonce start becoming popular?"
-
-        assert len(generated_document.answers) == 1
-        assert str(generated_document.answers[0]) == "in the late 1990s"
-
-    elif split == "validation":
-        assert generated_document.id == "56ddde6b9a695914005b9628"
-        assert generated_document.title == "Normans"
-        assert generated_document.text.startswith(
-            "The Normans (Norman: Nourmands; French: Normands; Latin: Normanni) were the people who in the "
-            "10th and 11th centuries gave their name to Normandy, a region in France."
-        )
-        assert len(generated_document.questions) == 1
-        assert str(generated_document.questions[0]) == "In what country is Normandy located?"
-
-        assert len(generated_document.answers) == 4
-        assert str(generated_document.answers[0]) == "France"
-        assert str(generated_document.answers[1]) == "France"
-        assert str(generated_document.answers[2]) == "France"
-        assert str(generated_document.answers[3]) == "France"
-
-    else:
-        raise ValueError(f"Unknown split: {split}")
+def test_hf_example(hf_example_fast, split):
+    assert hf_example_fast is not None
+    assert hf_example_fast == {
+        "id": "56be85543aeaaa14008c9063",
+        "title": "Beyoncé",
+        "context": "Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981) is an "
+        "American singer, songwriter, record producer and actress. Born and raised in Houston, "
+        "Texas, she performed in various singing and dancing competitions as a child, and rose to "
+        "fame in the late 1990s as lead singer of R&B girl-group Destiny's Child. Managed by her "
+        "father, Mathew Knowles, the group became one of the world's best-selling girl groups of "
+        "all time. Their hiatus saw the release of Beyoncé's debut album, Dangerously in Love "
+        "(2003), which established her as a solo artist worldwide, earned five Grammy Awards and "
+        'featured the Billboard Hot 100 number-one singles "Crazy in Love" and "Baby Boy".',
+        "question": "When did Beyonce start becoming popular?",
+        "answers": {"text": ["in the late 1990s"], "answer_start": [269]},
+    }
 
 
 @pytest.fixture(scope="module")
-def hf_example_back(generated_document):
-    return BUILDER_CLASS()._generate_example(generated_document)
+def generated_document_fast(hf_example_fast) -> DOCUMENT_TYPE:
+    return BUILDER_CLASS()._generate_document(hf_example_fast)
 
 
-def test_example_to_document_and_back(hf_example, hf_example_back):
-    assert hf_example_back == hf_example
+def test_generated_document_fast(generated_document_fast):
+    assert isinstance(generated_document_fast, DOCUMENT_TYPE)
+
+    assert generated_document_fast.id == "56be85543aeaaa14008c9063"
+    assert generated_document_fast.title == "Beyoncé"
+    assert generated_document_fast.text.startswith(
+        "Beyoncé Giselle Knowles-Carter (/biːˈjɒnseɪ/ bee-YON-say) (born September 4, 1981)"
+    )
+    assert len(generated_document_fast.questions) == 1
+    assert str(generated_document_fast.questions[0]) == "When did Beyonce start becoming popular?"
+
+    assert len(generated_document_fast.answers) == 1
+    assert str(generated_document_fast.answers[0]) == "in the late 1990s"
+
+
+def test_example_to_document_and_back_fast(hf_example_fast, generated_document_fast):
+    hf_example_back = BUILDER_CLASS()._generate_example(generated_document_fast)
+    assert hf_example_back == hf_example_fast
 
 
 @pytest.mark.slow
@@ -139,18 +106,28 @@ def test_example_to_document_and_back_all(hf_dataset):
 
 
 @pytest.fixture(scope="module")
-def dataset(split) -> Dataset:
+def pie_dataset(split) -> Dataset:
     return load_dataset(str(PIE_DATASET_PATH), split=split)
 
 
-def test_pie_dataset(dataset, split):
-    assert dataset is not None
-    assert len(dataset) == SPLIT_SIZES[split]
+@pytest.mark.slow
+def test_pie_dataset(pie_dataset, split):
+    assert pie_dataset is not None
+    assert len(pie_dataset) == SPLIT_SIZES[split]
 
 
 @pytest.fixture(scope="module")
-def document(dataset) -> DOCUMENT_TYPE:
-    doc = dataset[0]
+def pie_dataset_fast() -> IterableDataset:
+    return load_dataset(str(PIE_DATASET_PATH), split=SPLIT, streaming=True).take(STREAM_SIZE)
+
+
+def test_pie_dataset_fast(pie_dataset_fast):
+    assert pie_dataset is not None
+
+
+@pytest.fixture(scope="module")
+def document_fast(pie_dataset_fast) -> DOCUMENT_TYPE:
+    doc = list(pie_dataset_fast)[0]
     # we can not assert the real document type because it may come from a dataset loading script
     # downloaded to a temporary directory and thus have a different type object, although it is
     # semantically the same
@@ -159,18 +136,24 @@ def document(dataset) -> DOCUMENT_TYPE:
     return casted
 
 
-def test_compare_document_and_generated_document(document, generated_document):
-    assert document == generated_document
+def test_compare_document_and_generated_document(document_fast, generated_document_fast):
+    assert document_fast == generated_document_fast
 
 
-@pytest.fixture(scope="module")
-def dataset_with_extractive_qa_documents(dataset) -> Dataset:
-    return dataset.to_document_type(ExtractiveQADocument)
-
-
-def test_dataset_with_extractive_qa_documents(dataset_with_extractive_qa_documents, document):
-    assert dataset_with_extractive_qa_documents is not None
-    doc = dataset_with_extractive_qa_documents[0]
+def test_dataset_with_extractive_qa_documents_fast(pie_dataset_fast, document_fast):
+    dataset_with_extractive_qa_documents_fast = pie_dataset_fast.to_document_type(
+        ExtractiveQADocument
+    )
+    assert dataset_with_extractive_qa_documents_fast is not None
+    doc = list(dataset_with_extractive_qa_documents_fast)[0]
     assert isinstance(doc, ExtractiveQADocument)
-    doc_casted = document.as_type(ExtractiveQADocument)
+    doc_casted = document_fast.as_type(ExtractiveQADocument)
     assert doc == doc_casted
+
+
+@pytest.mark.slow
+def test_dataset_with_extractive_qa_documents_all(pie_dataset):
+    dataset_with_extractive_qa_documents = pie_dataset.to_document_type(ExtractiveQADocument)
+    assert dataset_with_extractive_qa_documents is not None
+    for doc in dataset_with_extractive_qa_documents:
+        assert isinstance(doc, ExtractiveQADocument)


### PR DESCRIPTION
This consistently splits the tests in fast and slow tests, where the former touch only the first two instances of the training set and the latter apply to all instances, but they are flagged with `@pytest.mark.slow` (i.e. they do not run on the GitHub CI).

It decreases the runtime of the `test` workflow on GitHub CI from `7m 21s` to `6m 13s`.

context: #107 