### PR TITLE
decrease `imdb` test time

### DIFF
--- a/tests/dataset_builders/pie/test_imdb.py
+++ b/tests/dataset_builders/pie/test_imdb.py
@@ -1,9 +1,10 @@
+import datasets
 import pytest
 from datasets import disable_caching, load_dataset
 from pytorch_ie.core import Document
 
 from dataset_builders.pie.imdb.imdb import Imdb
-from pie_datasets import DatasetDict
+from pie_datasets import Dataset
 from tests.dataset_builders.common import PIE_BASE_PATH
 
 disable_caching()
@@ -14,6 +15,10 @@ DOCUMENT_TYPE = BUILDER_CLASS.DOCUMENT_TYPE
 SPLIT_SIZES = {"test": 25000, "train": 25000, "unsupervised": 50000}
 HF_DATASET_PATH = BUILDER_CLASS.BASE_DATASET_PATH
 PIE_DATASET_PATH = PIE_BASE_PATH / DATASET_NAME
+
+# fast testing parameters
+SPLIT = "train"
+STREAM_SIZE = 3
 
 
 @pytest.fixture(scope="module", params=list(BUILDER_CLASS.DOCUMENT_CONVERTERS))
@@ -27,18 +32,18 @@ def split(request):
 
 
 @pytest.fixture(scope="module")
-def hf_dataset():
-    return load_dataset(str(HF_DATASET_PATH))
+def hf_dataset(split) -> datasets.Dataset:
+    return load_dataset(str(HF_DATASET_PATH), split=split)
 
 
-def test_hf_dataset(hf_dataset):
+def test_hf_dataset(hf_dataset, split):
     assert hf_dataset is not None
-    assert {name: len(ds) for name, ds in hf_dataset.items()} == SPLIT_SIZES
+    assert len(hf_dataset) == SPLIT_SIZES[split]
 
 
 @pytest.fixture(scope="module")
-def hf_example(hf_dataset, split):
-    return hf_dataset[split][0]
+def hf_example(hf_dataset):
+    return hf_dataset[0]
 
 
 def test_hf_example(hf_example, split):
@@ -63,25 +68,31 @@ def test_hf_example(hf_example, split):
 
 
 @pytest.fixture(scope="module")
-def generate_document_kwargs(hf_dataset, split) -> dict:
-    return BUILDER_CLASS()._generate_document_kwargs(hf_dataset[split]) or {}
+def builder() -> BUILDER_CLASS:
+    return BUILDER_CLASS()
 
 
 @pytest.fixture(scope="module")
-def generate_example_kwargs(hf_dataset, split) -> dict:
-    return BUILDER_CLASS()._generate_example_kwargs(hf_dataset[split]) or {}
+def generate_document_kwargs(hf_dataset, builder) -> dict:
+    return builder._generate_document_kwargs(hf_dataset) or {}
 
 
 @pytest.fixture(scope="module")
-def generated_document(hf_example, generate_document_kwargs) -> DOCUMENT_TYPE:
-    return BUILDER_CLASS()._generate_document(hf_example, **generate_document_kwargs)
+def generate_example_kwargs(hf_dataset, builder) -> dict:
+    return builder._generate_example_kwargs(hf_dataset) or {}
+
+
+@pytest.fixture(scope="module")
+def generated_document(hf_example, generate_document_kwargs, builder) -> DOCUMENT_TYPE:
+    return builder._generate_document(hf_example, **generate_document_kwargs)
 
 
 def test_generated_document(generated_document, split):
     assert isinstance(generated_document, DOCUMENT_TYPE)
     if split == "train":
         assert generated_document.text.startswith(
-            "I rented I AM CURIOUS-YELLOW from my video store because of all the controversy that surrounded it when it was first released in 1967."
+            "I rented I AM CURIOUS-YELLOW from my video store because of all the "
+            "controversy that surrounded it when it was first released in 1967."
         )
         assert len(generated_document.text) == 1640
         assert generated_document.label[0].label == "neg"
@@ -99,40 +110,36 @@ def test_generated_document(generated_document, split):
         raise ValueError(f"Unknown split: {split}")
 
 
-@pytest.fixture(scope="module")
-def hf_example_back(generated_document, generate_example_kwargs):
-    return BUILDER_CLASS()._generate_example(
+def test_example_to_document_and_back(hf_example, generated_document, generate_example_kwargs):
+    hf_example_back = BUILDER_CLASS()._generate_example(
         document=generated_document, **generate_example_kwargs
     )
-
-
-def test_example_to_document_and_back(hf_example, hf_example_back):
     assert hf_example_back == hf_example
 
 
 @pytest.mark.slow
 def test_example_to_document_and_back_all(
-    hf_dataset, generate_document_kwargs, generate_example_kwargs, split
+    hf_dataset, generate_document_kwargs, generate_example_kwargs, builder
 ):
-    for hf_ex in hf_dataset[split]:
-        doc = BUILDER_CLASS()._generate_document(example=hf_ex, **generate_document_kwargs)
-        hf_ex_back = BUILDER_CLASS()._generate_example(document=doc, **generate_example_kwargs)
+    for hf_ex in hf_dataset:
+        doc = builder._generate_document(example=hf_ex, **generate_document_kwargs)
+        hf_ex_back = builder._generate_example(document=doc, **generate_example_kwargs)
         assert hf_ex_back == hf_ex
 
 
 @pytest.fixture(scope="module")
-def dataset() -> DatasetDict:
-    return DatasetDict.load_dataset(str(PIE_DATASET_PATH))
+def pie_dataset(split) -> Dataset:
+    return load_dataset(str(PIE_DATASET_PATH), split=split)
 
 
-def test_pie_dataset(dataset):
-    assert dataset is not None
-    assert {name: len(ds) for name, ds in dataset.items()} == SPLIT_SIZES
+def test_pie_dataset(pie_dataset, split):
+    assert pie_dataset is not None
+    assert len(pie_dataset) == SPLIT_SIZES[split]
 
 
 @pytest.fixture(scope="module")
-def document(dataset, split) -> DOCUMENT_TYPE:
-    doc = dataset[split][0]
+def document(pie_dataset) -> DOCUMENT_TYPE:
+    doc = pie_dataset[0]
     # we can not assert the real document type because it may come from a dataset loading script
     # downloaded to a temporary directory and thus have a different type object, although it is
     # semantically the same
@@ -145,16 +152,10 @@ def test_compare_document_and_generated_document(document, generated_document):
     assert document == generated_document
 
 
-@pytest.fixture(scope="module")
-def dataset_with_extractive_qa_documents(dataset, converted_document_type) -> DatasetDict:
-    return dataset.to_document_type(converted_document_type)
-
-
-def test_dataset_with_extractive_qa_documents(
-    dataset_with_extractive_qa_documents, document, split, converted_document_type
-):
-    assert dataset_with_extractive_qa_documents is not None
-    doc = dataset_with_extractive_qa_documents[split][0]
-    assert isinstance(doc, converted_document_type)
+def test_dataset_with_converted_documents(pie_dataset, document, converted_document_type):
+    dataset_with_converted_documents = pie_dataset.to_document_type(converted_document_type)
+    assert dataset_with_converted_documents is not None
+    doc_converted = dataset_with_converted_documents[0]
+    assert isinstance(doc_converted, converted_document_type)
     doc_casted = document.as_type(converted_document_type)
-    assert doc == doc_casted
+    assert doc_converted == doc_casted

--- a/tests/dataset_builders/pie/test_imdb.py
+++ b/tests/dataset_builders/pie/test_imdb.py
@@ -4,7 +4,7 @@ from datasets import disable_caching, load_dataset
 from pytorch_ie.core import Document
 
 from dataset_builders.pie.imdb.imdb import Imdb
-from pie_datasets import Dataset
+from pie_datasets import Dataset, IterableDataset
 from tests.dataset_builders.common import PIE_BASE_PATH
 
 disable_caching()
@@ -36,35 +36,34 @@ def hf_dataset(split) -> datasets.Dataset:
     return load_dataset(str(HF_DATASET_PATH), split=split)
 
 
+@pytest.mark.slow
 def test_hf_dataset(hf_dataset, split):
     assert hf_dataset is not None
     assert len(hf_dataset) == SPLIT_SIZES[split]
 
 
 @pytest.fixture(scope="module")
-def hf_example(hf_dataset):
-    return hf_dataset[0]
+def hf_dataset_fast() -> datasets.IterableDataset:
+    return load_dataset(str(HF_DATASET_PATH), split=SPLIT, streaming=True).take(STREAM_SIZE)
 
 
-def test_hf_example(hf_example, split):
-    assert hf_example is not None
-    if split == "train":
-        assert hf_example["text"].startswith(
-            "I rented I AM CURIOUS-YELLOW from my video store because of all the controversy "
-            "that surrounded it when it was first released in 1967."
-        )
-        assert len(hf_example["text"]) == 1640
-        assert hf_example["label"] == 0
-    elif split == "test":
-        assert hf_example["text"].startswith("I love sci-fi and am willing to put up with a lot.")
-        assert len(hf_example["text"]) == 1386
-        assert hf_example["label"] == 0
-    elif split == "unsupervised":
-        assert hf_example["text"].startswith("This is just a precious little diamond.")
-        assert len(hf_example["text"]) == 892
-        assert hf_example["label"] == -1
-    else:
-        raise ValueError(f"Unknown split: {split}")
+def test_hf_dataset_fast(hf_dataset_fast):
+    assert hf_dataset_fast is not None
+
+
+@pytest.fixture(scope="module")
+def hf_example_fast(hf_dataset_fast):
+    return list(hf_dataset_fast)[0]
+
+
+def test_hf_example_fast(hf_example_fast):
+    assert hf_example_fast is not None
+    assert hf_example_fast["text"].startswith(
+        "I rented I AM CURIOUS-YELLOW from my video store because of all the controversy "
+        "that surrounded it when it was first released in 1967."
+    )
+    assert len(hf_example_fast["text"]) == 1640
+    assert hf_example_fast["label"] == 0
 
 
 @pytest.fixture(scope="module")
@@ -73,54 +72,35 @@ def builder() -> BUILDER_CLASS:
 
 
 @pytest.fixture(scope="module")
-def generate_document_kwargs(hf_dataset, builder) -> dict:
-    return builder._generate_document_kwargs(hf_dataset) or {}
+def generated_document_fast(hf_example_fast, hf_dataset_fast, builder) -> DOCUMENT_TYPE:
+    generate_document_kwargs = builder._generate_document_kwargs(hf_dataset_fast) or {}
+    return builder._generate_document(hf_example_fast, **generate_document_kwargs)
 
 
-@pytest.fixture(scope="module")
-def generate_example_kwargs(hf_dataset, builder) -> dict:
-    return builder._generate_example_kwargs(hf_dataset) or {}
-
-
-@pytest.fixture(scope="module")
-def generated_document(hf_example, generate_document_kwargs, builder) -> DOCUMENT_TYPE:
-    return builder._generate_document(hf_example, **generate_document_kwargs)
-
-
-def test_generated_document(generated_document, split):
-    assert isinstance(generated_document, DOCUMENT_TYPE)
-    if split == "train":
-        assert generated_document.text.startswith(
-            "I rented I AM CURIOUS-YELLOW from my video store because of all the "
-            "controversy that surrounded it when it was first released in 1967."
-        )
-        assert len(generated_document.text) == 1640
-        assert generated_document.label[0].label == "neg"
-    elif split == "test":
-        assert generated_document.text.startswith(
-            "I love sci-fi and am willing to put up with a lot."
-        )
-        assert len(generated_document.text) == 1386
-        assert generated_document.label[0].label == "neg"
-    elif split == "unsupervised":
-        assert generated_document.text.startswith("This is just a precious little diamond.")
-        assert len(generated_document.text) == 892
-        assert len(generated_document.label) == 0
-    else:
-        raise ValueError(f"Unknown split: {split}")
-
-
-def test_example_to_document_and_back(hf_example, generated_document, generate_example_kwargs):
-    hf_example_back = BUILDER_CLASS()._generate_example(
-        document=generated_document, **generate_example_kwargs
+def test_generated_document_fast(generated_document_fast):
+    assert isinstance(generated_document_fast, DOCUMENT_TYPE)
+    assert generated_document_fast.text.startswith(
+        "I rented I AM CURIOUS-YELLOW from my video store because of all the "
+        "controversy that surrounded it when it was first released in 1967."
     )
-    assert hf_example_back == hf_example
+    assert len(generated_document_fast.text) == 1640
+    assert generated_document_fast.label[0].label == "neg"
+
+
+def test_example_to_document_and_back_fast(
+    hf_example_fast, generated_document_fast, hf_dataset_fast, builder
+):
+    generate_example_kwargs = builder._generate_example_kwargs(hf_dataset_fast) or {}
+    hf_example_back = BUILDER_CLASS()._generate_example(
+        document=generated_document_fast, **generate_example_kwargs
+    )
+    assert hf_example_back == hf_example_fast
 
 
 @pytest.mark.slow
-def test_example_to_document_and_back_all(
-    hf_dataset, generate_document_kwargs, generate_example_kwargs, builder
-):
+def test_example_to_document_and_back_all(hf_dataset, builder):
+    generate_document_kwargs = builder._generate_document_kwargs(hf_dataset) or {}
+    generate_example_kwargs = builder._generate_example_kwargs(hf_dataset) or {}
     for hf_ex in hf_dataset:
         doc = builder._generate_document(example=hf_ex, **generate_document_kwargs)
         hf_ex_back = builder._generate_example(document=doc, **generate_example_kwargs)
@@ -132,14 +112,24 @@ def pie_dataset(split) -> Dataset:
     return load_dataset(str(PIE_DATASET_PATH), split=split)
 
 
+@pytest.mark.slow
 def test_pie_dataset(pie_dataset, split):
     assert pie_dataset is not None
     assert len(pie_dataset) == SPLIT_SIZES[split]
 
 
 @pytest.fixture(scope="module")
-def document(pie_dataset) -> DOCUMENT_TYPE:
-    doc = pie_dataset[0]
+def pie_dataset_fast() -> IterableDataset:
+    return load_dataset(str(PIE_DATASET_PATH), split=SPLIT, streaming=True).take(STREAM_SIZE)
+
+
+def test_pie_dataset_fast(pie_dataset_fast):
+    assert pie_dataset_fast is not None
+
+
+@pytest.fixture(scope="module")
+def document_fast(pie_dataset_fast) -> DOCUMENT_TYPE:
+    doc = list(pie_dataset_fast)[0]
     # we can not assert the real document type because it may come from a dataset loading script
     # downloaded to a temporary directory and thus have a different type object, although it is
     # semantically the same
@@ -148,14 +138,26 @@ def document(pie_dataset) -> DOCUMENT_TYPE:
     return casted
 
 
-def test_compare_document_and_generated_document(document, generated_document):
-    assert document == generated_document
+def test_compare_document_and_generated_document_fast(document_fast, generated_document_fast):
+    assert document_fast == generated_document_fast
 
 
-def test_dataset_with_converted_documents(pie_dataset, document, converted_document_type):
+def test_dataset_with_converted_documents_fast(
+    pie_dataset_fast, document_fast, converted_document_type
+):
+    dataset_with_converted_documents = pie_dataset_fast.to_document_type(converted_document_type)
+    assert dataset_with_converted_documents is not None
+    # check first document
+    doc_converted = list(dataset_with_converted_documents)[0]
+    assert isinstance(doc_converted, converted_document_type)
+    doc_casted = document_fast.as_type(converted_document_type)
+    assert doc_converted == doc_casted
+
+
+@pytest.mark.slow
+def test_dataset_with_converted_documents_all(pie_dataset, converted_document_type):
     dataset_with_converted_documents = pie_dataset.to_document_type(converted_document_type)
     assert dataset_with_converted_documents is not None
-    doc_converted = dataset_with_converted_documents[0]
-    assert isinstance(doc_converted, converted_document_type)
-    doc_casted = document.as_type(converted_document_type)
-    assert doc_converted == doc_casted
+    # check type of all documents
+    for converted_doc in dataset_with_converted_documents:
+        assert isinstance(converted_doc, converted_document_type)


### PR DESCRIPTION
Same as #108, but for the `imdb` datasets: This consistently splits the tests in fast and slow tests, where the former touch only the first two instances of the training set and the latter apply to all instances, but they are flagged with @pytest.mark.slow (i.e. they do not run on the GitHub CI).

This decreases the runtime for the `test` workflow on GitHub CI from `5m 27s` to `xxx`

context: #107 