### PR TITLE
increase timeout for test CI job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
 
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
       #----------------------------------------------


### PR DESCRIPTION
... from 10 to 30 minutes. Context: #107