### PR TITLE
use local data for `cdcp` pie dataset tests

### DIFF
--- a/tests/dataset_builders/pie/test_cdcp.py
+++ b/tests/dataset_builders/pie/test_cdcp.py
@@ -150,7 +150,7 @@ def test_example_to_document_and_back_all(hf_dataset, generate_document_kwargs, 
 
 @pytest.fixture(scope="module")
 def dataset() -> DatasetDict:
-    return DatasetDict.load_dataset(str(PIE_DATASET_PATH))
+    return DatasetDict.load_dataset(str(PIE_DATASET_PATH), data_dir=DATA_PATH)
 
 
 def test_pie_dataset(dataset):


### PR DESCRIPTION
To mitigate that the tests break if the source data (https://facultystaff.richmond.edu/~jpark/data/cdcp_acl17.zip) is not available, we use a local copy for all tests of the `cdcp` dataset. Previously, that was just the case for the HF related dataset tests.