### PR TITLE
separate test forkflow for datasets

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 
 [run]
-source = src,dataset_builders
+source = src
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 
 [run]
-source = src
+source = src,dataset_builders
 
 [report]
 exclude_lines =

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,13 @@ on:
     paths-ignore:
       - "dataset_builders/**"
       - "tests/dataset_builders/**"
+      - "tests/fixtures/dataset_builders/**"
   pull_request:
     branches: [main, "release/*"]
     paths-ignore:
       - "dataset_builders/**"
       - "tests/dataset_builders/**"
+      - "tests/fixtures/dataset_builders/**"
 
 jobs:
   tests:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,14 +4,14 @@ name: Tests
 on:
   push:
     branches: [main]
-    paths:
-      - "!dataset_builders/**"
-      - "!tests/dataset_builders/**"
+    paths-ignore:
+      - "dataset_builders/**"
+      - "tests/dataset_builders/**"
   pull_request:
     branches: [main, "release/*"]
-    paths:
-      - "!dataset_builders/**"
-      - "!tests/dataset_builders/**"
+    paths-ignore:
+      - "dataset_builders/**"
+      - "tests/dataset_builders/**"
 
 jobs:
   tests:

--- a/.github/workflows/test_datasets.yaml
+++ b/.github/workflows/test_datasets.yaml
@@ -4,16 +4,18 @@ name: Test Datasets
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "src/**"
-      - "tests/**"
-      - "!tests/dataset_builders/**"
+    paths:
+      - "src/dataset_builders/**"
+      - "tests/dataset_builders/**"
+      - "data/datasets/**"
+      - ".github/workflows/test_datasets.yaml"
   pull_request:
     branches: [main, "release/*"]
-    paths-ignore:
-      - "src/**"
-      - "tests/**"
-      - "!tests/dataset_builders/**"
+    paths:
+      - "src/dataset_builders/**"
+      - "tests/dataset_builders/**"
+      - "data/datasets/**"
+      - ".github/workflows/test_datasets.yaml"
 
 jobs:
   tests:

--- a/.github/workflows/test_datasets.yaml
+++ b/.github/workflows/test_datasets.yaml
@@ -1,17 +1,19 @@
 
-name: Tests
+name: Test Datasets
 
 on:
   push:
     branches: [main]
     paths:
-      - "!dataset_builders/**"
-      - "!tests/dataset_builders/**"
+      - "!src/**"
+      - "!tests/**"
+      - "tests/dataset_builders/**"
   pull_request:
     branches: [main, "release/*"]
     paths:
-      - "!dataset_builders/**"
-      - "!tests/dataset_builders/**"
+      - "!src/**"
+      - "!tests/**"
+      - "tests/dataset_builders/**"
 
 jobs:
   tests:
@@ -23,7 +25,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
 
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
       #----------------------------------------------
@@ -76,10 +78,10 @@ jobs:
       - name: Run tests with coverage
         run: |
           source .venv/bin/activate
-          pytest --ignore=tests/dataset_builders -k "not slow" --cov=src --cov-report term-missing --cov-report xml:coverage.xml
+          pytest tests/dataset_builders -k "not slow" --cov=dataset_builders --cov-report term-missing --cov-report xml:coverage_datasets.xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverage.xml
+          files: ./coverage_datasets.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_datasets.yaml
+++ b/.github/workflows/test_datasets.yaml
@@ -4,16 +4,16 @@ name: Test Datasets
 on:
   push:
     branches: [main]
-    paths:
-      - "!src/**"
-      - "!tests/**"
-      - "tests/dataset_builders/**"
+    paths-ignore:
+      - "src/**"
+      - "tests/**"
+      - "!tests/dataset_builders/**"
   pull_request:
     branches: [main, "release/*"]
-    paths:
-      - "!src/**"
-      - "!tests/**"
-      - "tests/dataset_builders/**"
+    paths-ignore:
+      - "src/**"
+      - "tests/**"
+      - "!tests/dataset_builders/**"
 
 jobs:
   tests:

--- a/.github/workflows/test_datasets.yaml
+++ b/.github/workflows/test_datasets.yaml
@@ -6,15 +6,17 @@ on:
     branches: [main]
     paths:
       - "src/dataset_builders/**"
-      - "tests/dataset_builders/**"
       - "data/datasets/**"
+      - "tests/dataset_builders/**"
+      - "tests/fixtures/dataset_builders/**"
       - ".github/workflows/test_datasets.yaml"
   pull_request:
     branches: [main, "release/*"]
     paths:
       - "src/dataset_builders/**"
-      - "tests/dataset_builders/**"
       - "data/datasets/**"
+      - "tests/dataset_builders/**"
+      - "tests/fixtures/dataset_builders/**"
       - ".github/workflows/test_datasets.yaml"
 
 jobs:

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import datasets
 from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pytorch_ie import Document
 from pytorch_ie.core import Annotation, AnnotationList, annotation_field
 from pytorch_ie.documents import TextBasedDocument
 
@@ -305,3 +306,8 @@ class BratBuilder(GeneratorBasedBuilder):
         return example_to_document(
             example, merge_fragmented_spans=self.config.merge_fragmented_spans
         )
+
+    def _generate_example(self, document: Document, **kwargs) -> Dict[str, Any]:
+        if not isinstance(document, (BratDocument, BratDocumentWithMergedSpans)):
+            raise TypeError(f"document type {type(document)} is not supported")
+        return document_to_example(document)

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -1,0 +1,190 @@
+from typing import Any
+
+import pytest
+from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pytorch_ie import Annotation
+
+from pie_datasets.builders.brat import BratAttribute, BratBuilder
+
+HF_EXAMPLES = [
+    {
+        "context": "Jane lives in Berlin.\n",
+        "file_name": "1",
+        "spans": {
+            "id": ["T1", "T2"],
+            "type": ["person", "city"],
+            "locations": [{"start": [0], "end": [4]}, {"start": [14], "end": [20]}],
+            "text": ["Jane", "Berlin"],
+        },
+        "relations": {"id": [], "type": [], "arguments": []},
+        "equivalence_relations": {"type": [], "targets": []},
+        "events": {"id": [], "type": [], "trigger": [], "arguments": []},
+        "attributions": {"id": [], "type": [], "target": [], "value": []},
+        "normalizations": {
+            "id": [],
+            "type": [],
+            "target": [],
+            "resource_id": [],
+            "entity_id": [],
+        },
+        "notes": {"id": [], "type": [], "target": [], "note": []},
+    },
+    {
+        "context": "Seattle is a rainy city. Jenny Durkan is the city's mayor.\n",
+        "file_name": "2",
+        "spans": {
+            "id": ["T1", "T2"],
+            "type": ["city", "person"],
+            "locations": [{"start": [0], "end": [7]}, {"start": [25], "end": [37]}],
+            "text": ["Seattle", "Jenny Durkan"],
+        },
+        "relations": {
+            "id": ["R1"],
+            "type": ["mayor_of"],
+            "arguments": [{"type": ["Arg1", "Arg2"], "target": ["T2", "T1"]}],
+        },
+        "equivalence_relations": {"type": [], "targets": []},
+        "events": {"id": [], "type": [], "trigger": [], "arguments": []},
+        "attributions": {
+            "id": ["A1", "A2"],
+            "type": ["factuality", "statement"],
+            "target": ["T1", "R1"],
+            "value": ["actual", "true"],
+        },
+        "normalizations": {
+            "id": [],
+            "type": [],
+            "target": [],
+            "resource_id": [],
+            "entity_id": [],
+        },
+        "notes": {"id": [], "type": [], "target": [], "note": []},
+    },
+]
+
+
+def resolve_annotation(annotation: Annotation) -> Any:
+    if annotation.target is None:
+        return None
+    if isinstance(annotation, LabeledMultiSpan):
+        return (
+            [annotation.target[start:end] for start, end in annotation.slices],
+            annotation.label,
+        )
+    elif isinstance(annotation, LabeledSpan):
+        return (annotation.target[annotation.start : annotation.end], annotation.label)
+    elif isinstance(annotation, BinaryRelation):
+        return (
+            resolve_annotation(annotation.head),
+            annotation.label,
+            resolve_annotation(annotation.tail),
+        )
+    elif isinstance(annotation, BratAttribute):
+        result = (resolve_annotation(annotation.annotation), annotation.label)
+        if annotation.value is not None:
+            return result + (annotation.value,)
+        else:
+            return result
+    else:
+        raise TypeError(f"Unknown annotation type: {type(annotation)}")
+
+
+@pytest.fixture(scope="module", params=BratBuilder.BUILDER_CONFIGS)
+def config_name(request) -> str:
+    return request.param.name
+
+
+def test_config_names(config_name):
+    assert config_name in ["default", "merge_fragmented_spans"]
+
+
+@pytest.fixture(scope="module")
+def builder(config_name: str) -> BratBuilder:
+    return BratBuilder(name=config_name)
+
+
+def test_builder(builder):
+    assert builder is not None
+
+
+@pytest.fixture(scope="module", params=range(len(HF_EXAMPLES)))
+def sample_idx(request) -> int:
+    return request.param
+
+
+def test_generate_document(builder, sample_idx, config_name):
+    hf_example = HF_EXAMPLES[sample_idx]
+    kwargs = dict()
+    generated_document = builder._generate_document(example=hf_example, **kwargs)
+    resolved_spans = [resolve_annotation(annotation=span) for span in generated_document.spans]
+    resolved_relations = [
+        resolve_annotation(relation) for relation in generated_document.relations
+    ]
+    if sample_idx == 0:
+        assert len(generated_document.spans) == 2
+        assert len(generated_document.relations) == 0
+        assert len(generated_document.span_attributes) == 0
+        assert len(generated_document.relation_attributes) == 0
+
+        if config_name == "default":
+            assert resolved_spans[0] == (["Jane"], "person")
+            assert resolved_spans[1] == (["Berlin"], "city")
+        elif config_name == "merge_fragmented_spans":
+            assert resolved_spans[0] == ("Jane", "person")
+            assert resolved_spans[1] == ("Berlin", "city")
+        else:
+            raise ValueError(f"Unknown dataset variant: {config_name}")
+
+    elif sample_idx == 1:
+        assert len(generated_document.spans) == 2
+        assert len(generated_document.relations) == 1
+        assert len(generated_document.span_attributes) == 1
+        assert len(generated_document.relation_attributes) == 1
+
+        resolved_span_attributes = [
+            resolve_annotation(attribute) for attribute in generated_document.span_attributes
+        ]
+        resolved_relation_attributes = [
+            resolve_annotation(attribute) for attribute in generated_document.relation_attributes
+        ]
+
+        if config_name == "default":
+            assert resolved_spans[0] == (["Seattle"], "city")
+            assert resolved_spans[1] == (["Jenny Durkan"], "person")
+            assert resolved_relations[0] == (
+                (["Jenny Durkan"], "person"),
+                "mayor_of",
+                (["Seattle"], "city"),
+            )
+            assert resolved_span_attributes[0] == ((["Seattle"], "city"), "factuality", "actual")
+            assert resolved_relation_attributes[0] == (
+                ((["Jenny Durkan"], "person"), "mayor_of", (["Seattle"], "city")),
+                "statement",
+                "true",
+            )
+        elif config_name == "merge_fragmented_spans":
+            assert resolved_spans[0] == ("Seattle", "city")
+            assert resolved_spans[1] == ("Jenny Durkan", "person")
+            assert resolved_relations[0] == (
+                ("Jenny Durkan", "person"),
+                "mayor_of",
+                ("Seattle", "city"),
+            )
+            assert resolved_span_attributes[0] == (("Seattle", "city"), "factuality", "actual")
+            assert resolved_relation_attributes[0] == (
+                (("Jenny Durkan", "person"), "mayor_of", ("Seattle", "city")),
+                "statement",
+                "true",
+            )
+        else:
+            raise ValueError(f"Unknown dataset variant: {config_name}")
+    else:
+        raise ValueError(f"Unknown sample index: {sample_idx}")
+
+
+def test_example_to_document_and_back_all(builder):
+    for hf_example in HF_EXAMPLES:
+        doc = builder._generate_document(hf_example)
+        assert isinstance(doc, builder.document_type)
+        hf_example_back = builder._generate_example(doc)
+        assert hf_example == hf_example_back


### PR DESCRIPTION
This PR outsources tests to new `test_datasets.yaml` GitHub CI workflow. This is the first approach to handle #112.

The following items in the workflow configs are adjusted:
 - `on.(push|pull_request).paths(-ignore)`: only execute the workflow if the respective files did change
 - add `--ignore=tests/dataset_builders` / `tests/dataset_builders` to `pytest` arguments: only execute the respective tests
 - set `--cov=src` / `--cov`: only calculate the coverage for the respective files
 - `coverage.xml` / `coverage_datasets.xml` to save and upload the coverage report

Notes:
 - this also adds new tests for the `BratBuilder`. Until now, this was covered by the Brat dataset tests, but since these are now separated, we also need explicit tests for the builder.
 - this also implements `BratBuilder._generate_example()` to make it "API-complete"