### PR TITLE
brat: use annotation types from pytorch-ie

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1213,13 +1213,13 @@ files = [
 
 [[package]]
 name = "pytorch-ie"
-version = "0.30.2"
+version = "0.30.3"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "pytorch_ie-0.30.2-py3-none-any.whl", hash = "sha256:3ba70c27e999824ae0e568ab3cf31b89f8cf253c9b08653a380422c93a9fea0f"},
-    {file = "pytorch_ie-0.30.2.tar.gz", hash = "sha256:b4e45c72e9d461d0c8ba1deb83341bffa51265b89be087ff54924c7f700cfb21"},
+    {file = "pytorch_ie-0.30.3-py3-none-any.whl", hash = "sha256:45b0d32817ee5803e785cd75c88eb4fc84cc5764eb05f199a820d22db3f434e3"},
+    {file = "pytorch_ie-0.30.3.tar.gz", hash = "sha256:9743d27e430ba4f21a62362a8873cf9d71549477231b6216a19827ec6f3aa963"},
 ]
 
 [package.dependencies]
@@ -2165,4 +2165,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f9af09e2df802bc9f18ec18345e2d611dbc8f689e44723dce66ff51cd1dc5560"
+content-hash = "b08950259b0c8dc04a2a975f39c4a835b4fb3f327afced1e3bc6a152a4966a18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytorch-ie = ">=0.29.4,<0.31.0"
+pytorch-ie = ">=0.30.3,<0.31.0"
 # <2.16.0 because of https://github.com/ArneBinder/pie-datasets/issues/93
 datasets = ">=2.14.0,<2.16.0"
 # this was manually added because we get a conflict with pyarrow otherwise

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -4,9 +4,8 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import datasets
-from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
-from pytorch_ie import Document
-from pytorch_ie.core import Annotation, AnnotationList, annotation_field
+from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
 from pytorch_ie.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -1,8 +1,8 @@
 from typing import Any
 
 import pytest
-from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
-from pytorch_ie import Annotation
+from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pytorch_ie.core import Annotation
 from pytorch_ie.documents import TextBasedDocument
 
 from pie_datasets.builders.brat import BratAttribute, BratBuilder


### PR DESCRIPTION
This requires [pytorch-ie>=0.30.3](https://github.com/ArneBinder/pytorch-ie/releases/tag/v0.30.3). It raises the minimum minor pytorch-ie version, so this is breaking.