### PR TITLE
increase timeout for test_dataset CI job 

### DIFF
--- a/.github/workflows/test_pie_datasets.yaml
+++ b/.github/workflows/test_pie_datasets.yaml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         # List matrix strategy from datasets dynamically collected in the previous job
         dataset: ${{fromJson(needs.collect_modified_datasets.outputs.datasets)}}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - run: echo "test dataset ${{matrix.dataset}}"
       - name: Check out repository


### PR DESCRIPTION
... to 15 minutes (otherwise the test for `conll2012_ontonotesv5` fails)