### PR TITLE
fix `aae2` when passing `conversion_method` to `load_dataset`

### DIFF
--- a/dataset_builders/pie/aae2/aae2.py
+++ b/dataset_builders/pie/aae2/aae2.py
@@ -131,11 +131,12 @@ class ArgumentAnnotatedEssaysV2Config(BratConfig):
             conversion_method: either "connect_first" or "connect_all", see convert_aae2_claim_attributions_to_relations
             **kwargs: keyword arguments forwarded to super.
         """
-        super().__init__(**kwargs)
+        super().__init__(merge_fragmented_spans=True, **kwargs)
         self.conversion_method = conversion_method
 
 
 class ArgumentAnnotatedEssaysV2(BratBuilder):
+    BUILDER_CONFIG_CLASS = ArgumentAnnotatedEssaysV2Config
     BASE_DATASET_PATH = "DFKI-SLT/brat"
     BASE_DATASET_REVISION = "bb8c37d84ddf2da1e691d226c55fef48fd8149b5"
 
@@ -148,7 +149,6 @@ class ArgumentAnnotatedEssaysV2(BratBuilder):
     BUILDER_CONFIGS = [
         ArgumentAnnotatedEssaysV2Config(
             name=BratBuilder.DEFAULT_CONFIG_NAME,
-            merge_fragmented_spans=True,
             conversion_method="connect_first",
         ),
     ]


### PR DESCRIPTION
In this case, the `BUILDER_CONFIG_CLASS` is used to create a new config from scratch. However, we still need to pass `merge_fragmented_spans=True`, otherwise we get documents in an unexpected format:  `BratDocument` which has multi-spans, but we want `BratDocumentWithMergedSpans` with simple spans. This PR sets the `BUILDER_CONFIG_CLASS` and hardcodes `merge_fragmented_spans=True`.