### PR TITLE
add brat note

### DIFF
--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -1,8 +1,7 @@
 import dataclasses
-import json
 import logging
 from collections import defaultdict
-from typing import Any, Dict, Hashable, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import datasets
 from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
@@ -21,7 +20,7 @@ class BratAttribute(Annotation):
     value: Optional[str] = None
     score: Optional[float] = dataclasses.field(default=None, compare=False)
 
-    def resolve(self) -> Hashable:
+    def resolve(self) -> Any:
         value = self.value if self.value is not None else True
         return value, self.label, self.annotation.resolve()
 
@@ -32,7 +31,7 @@ class BratNote(Annotation):
     label: str
     value: str
 
-    def resolve(self) -> Hashable:
+    def resolve(self) -> Any:
         return self.value, self.label, self.annotation.resolve()
 
 
@@ -181,7 +180,7 @@ def example_to_document(
     }
 
     doc.metadata["note_ids"] = []
-    notes_dicts: Dict[Hashable, Dict[str, Any]] = dict()
+    notes_dicts: Dict[Annotation, Dict[str, Any]] = dict()
     for note_dict in dl2ld(example["notes"]):
         target_id = note_dict["target"]
         if target_id not in id2annotation:

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Hashable, List, Optional, Tuple, Union
 
 import datasets
 from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
@@ -20,12 +20,21 @@ class BratAttribute(Annotation):
     value: Optional[str] = None
     score: Optional[float] = dataclasses.field(default=None, compare=False)
 
+    def resolve(self) -> Hashable:
+        if self.value is None:
+            return self.label, self.annotation.resolve()
+        else:
+            return self.value, self.label, self.annotation.resolve()
+
 
 @dataclasses.dataclass(eq=True, frozen=True)
 class BratNote(Annotation):
     annotation: Annotation
     label: str
     value: str
+
+    def resolve(self) -> Hashable:
+        return self.value, self.label, self.annotation.resolve()
 
 
 @dataclasses.dataclass

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -182,6 +182,7 @@ def example_to_document(
     }
 
     doc.metadata["note_ids"] = []
+    notes_dicts: Dict[Hashable, Dict[str, Any]] = dict()
     for note_dict in dl2ld(example["notes"]):
         target_id = note_dict["target"]
         if target_id not in id2annotation:
@@ -192,6 +193,13 @@ def example_to_document(
             label=note_dict["type"],
             value=note_dict["note"],
         )
+        if note.resolve() in notes_dicts:
+            prev_note = notes_dicts[note.resolve()]
+            logger.warning(
+                f"document {doc.id}: annotation exists twice: {prev_note['id']} and {note_dict['id']} "
+                f"are identical"
+            )
+        notes_dicts[note.resolve()] = note_dict
         doc.notes.append(note)
         doc.metadata["note_ids"].append(note_dict["id"])
 

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -22,10 +22,8 @@ class BratAttribute(Annotation):
     score: Optional[float] = dataclasses.field(default=None, compare=False)
 
     def resolve(self) -> Hashable:
-        if self.value is None:
-            return self.label, self.annotation.resolve()
-        else:
-            return self.value, self.label, self.annotation.resolve()
+        value = self.value if self.value is not None else True
+        return value, self.label, self.annotation.resolve()
 
 
 @dataclasses.dataclass(eq=True, frozen=True)

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -322,9 +322,8 @@ def document_to_example(
         }
         if note_annotation in notes_dicts:
             prev_ann_dict = notes_dicts[note_annotation]
-            ann_dict = note_annotation
             logger.warning(
-                f"document {document.id}: annotation exists twice: {prev_ann_dict['id']} and {ann_dict['id']} "
+                f"document {document.id}: annotation exists twice: {prev_ann_dict['id']} and {note_dict['id']} "
                 f"are identical"
             )
         notes_dicts[note_annotation] = note_dict

--- a/src/pie_datasets/builders/brat.py
+++ b/src/pie_datasets/builders/brat.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 import logging
 from collections import defaultdict
 from typing import Any, Dict, Hashable, List, Optional, Tuple, Union
@@ -193,15 +194,18 @@ def example_to_document(
             label=note_dict["type"],
             value=note_dict["note"],
         )
-        if note.resolve() in notes_dicts:
-            prev_note = notes_dicts[note.resolve()]
+        doc.notes.append(note)
+        doc.metadata["note_ids"].append(note_dict["id"])
+
+        # check for duplicates: this works only because the note was already added to the document
+        # (annotations attached to different documents are never equal)
+        if note in notes_dicts:
+            prev_note = notes_dicts[note]
             logger.warning(
                 f"document {doc.id}: annotation exists twice: {prev_note['id']} and {note_dict['id']} "
                 f"are identical"
             )
-        notes_dicts[note.resolve()] = note_dict
-        doc.notes.append(note)
-        doc.metadata["note_ids"].append(note_dict["id"])
+        notes_dicts[note] = note_dict
 
     return doc
 

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -12,6 +12,7 @@ from pie_datasets.builders.brat import (
     BratBuilder,
     BratDocument,
     BratDocumentWithMergedSpans,
+    BratNote,
 )
 
 HF_EXAMPLES = [
@@ -258,3 +259,19 @@ def test_brat_attribute():
     attribute_with_value = BratAttribute(annotation=span, label="actual", value="maybe")
     doc.attributes.append(attribute_with_value)
     assert attribute_with_value.resolve() == ("maybe", "actual", ("person", "Jane"))
+
+
+def test_brat_note():
+    @dataclasses.dataclass
+    class ExampleDocument(TextBasedDocument):
+        spans: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        notes: AnnotationList[BratNote] = annotation_field(target="spans")
+
+    doc = ExampleDocument(text="Jane lives in Berlin.")
+    span = LabeledSpan(start=0, end=4, label="person")
+    doc.spans.append(span)
+
+    note = BratNote(annotation=span, label="AnnotatorNotes", value="not sure if this is correct")
+    doc.notes.append(note)
+
+    assert note.resolve() == ("not sure if this is correct", "AnnotatorNotes", ("person", "Jane"))

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -210,14 +210,21 @@ def test_example_to_document_exceptions(builder):
     assert str(exc_info.value) == "note target T3 not found in any of the target layers"
 
 
-def test_document_to_example_warnings(builder):
+def test_document_to_example_warnings(builder, caplog):
     example = HF_EXAMPLES[0].copy()
     example["notes"] = {
-        "id": ["#1", "#1"],
+        "id": ["#1", "#2"],
         "type": ["AnnotatorNotes", "AnnotatorNotes"],
         "target": ["T1", "T1"],
         "note": ["last name is omitted", "last name is omitted"],
     }
 
-    doc = builder._generate_document(example)
-    builder._generate_example(doc)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        doc = builder._generate_document(example)
+    assert caplog.messages == []
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        builder._generate_example(doc)
+    assert caplog.messages == ['document 1: annotation exists twice: #1 and #2 are identical']

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -3,7 +3,7 @@ from typing import Union
 import pytest
 from pytorch_ie.documents import TextBasedDocument
 
-from src.pie_datasets.builders.brat import (
+from pie_datasets.builders.brat import (
     BratBuilder,
     BratDocument,
     BratDocumentWithMergedSpans,

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -58,7 +58,7 @@ HF_EXAMPLES = [
             "id": ["A1", "A2"],
             "type": ["factuality", "statement"],
             "target": ["T1", "R1"],
-            "value": ["actual", None],
+            "value": ["actual", "true"],
         },
         "normalizations": {
             "id": [],
@@ -141,6 +141,7 @@ def test_generate_document(builder, hf_example):
             ]
             assert generated_document.relation_attributes.resolve() == [
                 (
+                    "true",
                     "statement",
                     ("mayor_of", (("person", ("Jenny Durkan",)), ("city", ("Seattle",)))),
                 )
@@ -164,7 +165,11 @@ def test_generate_document(builder, hf_example):
                 ("actual", "factuality", ("city", "Seattle"))
             ]
             assert generated_document.relation_attributes.resolve() == [
-                ("statement", ("mayor_of", (("person", "Jenny Durkan"), ("city", "Seattle"))))
+                (
+                    "true",
+                    "statement",
+                    ("mayor_of", (("person", "Jenny Durkan"), ("city", "Seattle"))),
+                )
             ]
             assert generated_document.notes.resolve() == [
                 (

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Union
 
 import pytest
@@ -222,9 +223,9 @@ def test_document_to_example_warnings(builder, caplog):
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         doc = builder._generate_document(example)
-    assert caplog.messages == []
+    assert caplog.messages == ["document 1: annotation exists twice: #1 and #2 are identical"]
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         builder._generate_example(doc)
-    assert caplog.messages == ['document 1: annotation exists twice: #1 and #2 are identical']
+    assert caplog.messages == ["document 1: annotation exists twice: #1 and #2 are identical"]


### PR DESCRIPTION
This PR handles the note annotations by creating a `BratNote` data class. Note annotations are the free form text in brat annotation file that targets either a document or an annotation. `BratNote` is added to `BratDocument` as well as `BratDocumentWithMergedSpans`. `BratNote` targets *all* other annotation layers. 

`resolve()` method is added to both `BratNote` and `BratAttribute` that returns the value, label and the annotation associated with the `BratNote` as well as BratAttribute.