### PR TITLE
poetry dependencies for torch in macOS with M-series

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2523,4 +2523,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0d1743557cc4dc10e985045497e40bac5734cb16435e650005bb22fa0852b4e9"
+content-hash = "a0c2cbe4c03c19204cd204d2d9a2af1738f324924f3d5ab556e1b66f71c929b3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1176,6 +1176,7 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
+    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_aarch64.whl", hash = "sha256:98103729cc5226e13ca319a10bbf9433bbbd44ef64fe72f45f067cacc14b8d27"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f9b37bc5c8cf7509665cb6ada5aaa0ce65618f2332b7d3e78e9790511f111212"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-win_amd64.whl", hash = "sha256:e782564d705ff0bf61ac3e1bf730166da66dd2fe9012f111ede5fc49b64ae697"},
 ]
@@ -2522,4 +2523,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ea3946780a22876c33999299c9fa462359bcee85533566a327c9b1317b170c6e"
+content-hash = "0d1743557cc4dc10e985045497e40bac5734cb16435e650005bb22fa0852b4e9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1176,7 +1176,6 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_aarch64.whl", hash = "sha256:98103729cc5226e13ca319a10bbf9433bbbd44ef64fe72f45f067cacc14b8d27"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f9b37bc5c8cf7509665cb6ada5aaa0ce65618f2332b7d3e78e9790511f111212"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-win_amd64.whl", hash = "sha256:e782564d705ff0bf61ac3e1bf730166da66dd2fe9012f111ede5fc49b64ae697"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,11 @@ pyarrow = "^13"
 pie-modules = ">=0.11.1,<0.13.0"
 torch = [
     # default
-    {version = "^2.1.0+cpu", source = "pytorch", markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'"},
+    {version = "^2.1.0+cpu", source = "pytorch", markers = "sys_platform != 'darwin' or platform_machine != 'arm64' and platform_machine != 'x86_64'"},
     # torch >= 2.3.0 is not available for macOS on intel
     {version = ">=2.1.0,<2.3.0", source = "pypi", markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'"},
+    # macOS with M-series
+    {version = "^2.1.0", source = "pypi", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"},
 ]
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ pyarrow = "^13"
 pie-modules = ">=0.11.1,<0.13.0"
 torch = [
     # default
-    {version = "^2.1.0+cpu", source = "pytorch", markers = "sys_platform != 'darwin' or platform_machine != 'arm64' and platform_machine != 'x86_64'"},
+    {version = "^2.1.0+cpu", source = "pytorch", markers = "sys_platform != 'darwin' or (platform_machine != 'arm64' and platform_machine != 'x86_64')"},
     # torch >= 2.3.0 is not available for macOS on intel
     {version = ">=2.1.0,<2.3.0", source = "pypi", markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'"},
     # macOS with M-series


### PR DESCRIPTION
This PR adds dependencies for torch in macOS with M-series. Currently tested on M1 only.