### PR TITLE
update brat attribute layers

### DIFF
--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -7,7 +7,7 @@ from pie_core import AnnotationLayer, annotation_field
 from pie_modules.annotations import LabeledSpan
 from pie_modules.documents import TextBasedDocument
 
-from pie_datasets.builders.brat import (
+from src.pie_datasets.builders.brat import (
     BratAttribute,
     BratBuilder,
     BratDocument,
@@ -113,8 +113,7 @@ def test_generate_document(builder, hf_example):
 
     if hf_example == HF_EXAMPLES[0]:
         assert len(generated_document.relations) == 0
-        assert len(generated_document.span_attributes) == 0
-        assert len(generated_document.relation_attributes) == 0
+        assert len(generated_document.attributes) == 0
 
         if builder.config.name == "default":
             assert generated_document.spans.resolve() == [
@@ -141,16 +140,15 @@ def test_generate_document(builder, hf_example):
             assert generated_document.relations.resolve() == [
                 ("mayor_of", (("person", ("Jenny Durkan",)), ("city", ("Seattle",))))
             ]
-            assert generated_document.span_attributes.resolve() == [
-                ("actual", "factuality", ("city", ("Seattle",)))
-            ]
-            assert generated_document.relation_attributes.resolve() == [
+            assert generated_document.attributes.resolve() == [
+                ("actual", "factuality", ("city", ("Seattle",))),
                 (
                     "true",
                     "statement",
                     ("mayor_of", (("person", ("Jenny Durkan",)), ("city", ("Seattle",)))),
-                )
+                ),
             ]
+
             assert generated_document.notes.resolve() == [
                 (
                     "single relation",
@@ -166,15 +164,13 @@ def test_generate_document(builder, hf_example):
             assert generated_document.relations.resolve() == [
                 ("mayor_of", (("person", "Jenny Durkan"), ("city", "Seattle")))
             ]
-            assert generated_document.span_attributes.resolve() == [
-                ("actual", "factuality", ("city", "Seattle"))
-            ]
-            assert generated_document.relation_attributes.resolve() == [
+            assert generated_document.attributes.resolve() == [
+                ("actual", "factuality", ("city", "Seattle")),
                 (
                     "true",
                     "statement",
                     ("mayor_of", (("person", "Jenny Durkan"), ("city", "Seattle"))),
-                )
+                ),
             ]
             assert generated_document.notes.resolve() == [
                 (

--- a/tests/unit/builder/test_brat_builder.py
+++ b/tests/unit/builder/test_brat_builder.py
@@ -201,21 +201,7 @@ def test_document_to_example_wrong_type(builder):
     assert str(exc_info.value) == f"document type {type(doc)} is not supported"
 
 
-def test_example_to_document_exceptions(builder):
-    example = HF_EXAMPLES[0].copy()
-    example["notes"] = {
-        "id": ["#1"],
-        "type": ["AnnotatorNotes"],
-        "target": ["T3"],
-        "note": ["last name is omitted"],
-    }
-
-    kwargs = dict()
-
-    with pytest.raises(Exception) as exc_info:
-        builder._generate_document(example=example, **kwargs)
-    assert str(exc_info.value) == "note target T3 not found in any of the target layers"
-
+def test_example_to_document_missing_attribute_target(builder):
     example = HF_EXAMPLES[1].copy()
     example["attributions"] = {
         "id": ["A1"],
@@ -226,8 +212,28 @@ def test_example_to_document_exceptions(builder):
         "value": ["actual"],
     }
     with pytest.raises(Exception) as exc_info:
-        builder._generate_document(example=example, **kwargs)
-    assert str(exc_info.value) == "only span and relation attributes are supported yet"
+        builder._generate_document(example=example)
+    assert (
+        str(exc_info.value)
+        == "attribute target annotation N1 not found in any of the target layers (spans, relations)"
+    )
+
+
+def test_example_to_document_missing_note_target(builder):
+    example = HF_EXAMPLES[0].copy()
+    example["notes"] = {
+        "id": ["#1"],
+        "type": ["AnnotatorNotes"],
+        "target": ["T3"],
+        "note": ["last name is omitted"],
+    }
+
+    with pytest.raises(Exception) as exc_info:
+        builder._generate_document(example=example)
+    assert (
+        str(exc_info.value)
+        == "note target annotation T3 not found in any of the target layers (spans, relations, attributes)"
+    )
 
 
 def test_document_to_example_warnings(builder, caplog):


### PR DESCRIPTION
This PR adds a breaking change to the previous implementation of annotation attributes in `BratDocument` and `BratDocumentWithMergedSpans`. Previously, both of these documents had separate layers for span and relation attributes as `span_attributes` and `relation_attributes` respectively. With the new changes, the attributes are stored in each document's `attribute` layer, which targets spans *and* relations.

The following example shows how annotation attributes can be added:

```diff

span_attribute = BratAttribute(annotation=span, label="actual")
- doc.span_attributes.extend(span_attribute)
+ doc.attributes.append(span_attribute)
assert span_attribute.resolve() == (True, "actual", ("person", "Jane"))

```

follow-up (should happen after the breaking release):
 - [ ] fix `brat` dataset builder
 - [ ] fix `aae2` dataset builder
 - [ ] fix `sciarg` dataset builder (no failing tests, but `ConvertedBratDocument` uses spans in theory)