### PR TITLE
`sciarg`: fix partitioning

### DIFF
--- a/dataset_builders/pie/sciarg/sciarg.py
+++ b/dataset_builders/pie/sciarg/sciarg.py
@@ -123,7 +123,8 @@ class SciArg(BratBuilder):
     def document_converters(self) -> DocumentConvertersType:
         regex_partitioner = RegexPartitioner(
             partition_layer_name="labeled_partitions",
-            pattern="<([^>/]+)>.*</\\1>",
+            # find matching tags, allow newlines in between (s flag) and capture the tag name
+            pattern="<([^>/]+)>(?s:.)*?</\\1>",
             label_group_id=1,
             label_whitelist=["Title", "Abstract", "H1"],
             skip_initial_partition=True,

--- a/tests/dataset_builders/pie/sciarg/test_sciarg.py
+++ b/tests/dataset_builders/pie/sciarg/test_sciarg.py
@@ -50,10 +50,12 @@ FULL_LABEL_COUNTS = {
             "supports": 5789,
         },
         "spans": {"background_claim": 3291, "data": 4297, "own_claim": 6004},
+        "labeled_partitions": {"Abstract": 39, "H1": 340, "Title": 40},
     },
     "resolve_parts_of_same": {
         "relations": {"contradicts": 696, "semantically_same": 44, "supports": 5788},
         "spans": {"background_claim": 2752, "data": 4093, "own_claim": 5450},
+        "labeled_partitions": {"Abstract": 39, "H1": 340, "Title": 40},
     },
 }
 
@@ -257,7 +259,7 @@ def converted_dataset(dataset, target_document_type) -> Optional[DatasetDict]:
     return dataset.to_document_type(target_document_type)
 
 
-def test_converted_datasets(converted_dataset, dataset_variant):
+def test_converted_datasets(converted_dataset, dataset_variant, target_document_type):
     if converted_dataset is not None:
         split_sizes = {name: len(ds) for name, ds in converted_dataset.items()}
         assert split_sizes == SPLIT_SIZES
@@ -280,9 +282,13 @@ def test_converted_datasets(converted_dataset, dataset_variant):
 
         if TEST_FULL_DATASET:
             expected_label_counts = {
-                layer_name_mapping[ln]: value
+                layer_name_mapping.get(ln, ln): value
                 for ln, value in FULL_LABEL_COUNTS[dataset_variant].items()
             }
+            if not issubclass(target_document_type, TextDocumentWithLabeledPartitions):
+                expected_label_counts = {
+                    k: v for k, v in expected_label_counts.items() if k != "labeled_partitions"
+                }
             assert_dataset_label_counts(converted_dataset, expected_label_counts)
 
 

--- a/tests/dataset_builders/pie/sciarg/test_sciarg.py
+++ b/tests/dataset_builders/pie/sciarg/test_sciarg.py
@@ -70,11 +70,7 @@ FULL_LABEL_COUNTS_CONVERTED = {
     variant: {CONVERTED_LAYER_MAPPING[variant][ln]: value for ln, value in counts.items()}
     for variant, counts in FULL_LABEL_COUNTS.items()
 }
-LABELED_PARTITION_COUNTS = {
-    "Abstract": 39,
-    "H1": 340,
-    "Title": 40,
-}
+LABELED_PARTITION_COUNTS = {"Abstract": 40, "H1": 340, "Title": 40}
 
 
 def resolve_annotation(annotation: Annotation) -> Any:


### PR DESCRIPTION
This PR
- adds a test that asserts label counts for `labeled_partitions`
- changes `RegexPartitioner` `pattern` to `"<([^>/]+)>(?s:.)*?</\\1>"`: find matching tags non-greedy (`*?`), allow newlines in between (`s` flag) and capture the tag name

This affects only document A32 where the abstract was not identified before but now it is.