### PR TITLE
Extend split_mappings format in `concatenate_dataset_dicts()`

### DIFF
--- a/tests/unit/core/test_dataset_dict.py
+++ b/tests/unit/core/test_dataset_dict.py
@@ -724,3 +724,19 @@ def test_concatenate_dataset_dicts(tbga_extract, comagc_extract):
     assert all(
         [ds.metadata["dataset_name"] in ["tbga", "comagc"] for ds in concatenated_dataset["train"]]
     )
+
+    concatenated_dataset_with_list_in_mapping = concatenate_dataset_dicts(
+        inputs={"tbga": tbga_extract, "comagc": comagc_extract},
+        split_mappings={"train": {"tbga": ["train", "test"], "comagc": "train"}},
+        clear_metadata=True,
+    )
+
+    assert len(concatenated_dataset_with_list_in_mapping["train"]) == len(
+        tbga_extract["train"]
+    ) + len(tbga_extract["test"]) + len(comagc_extract["train"])
+    assert all(
+        [
+            ds.metadata["dataset_name"] in ["tbga", "comagc"]
+            for ds in concatenated_dataset_with_list_in_mapping["train"]
+        ]
+    )


### PR DESCRIPTION
`concatenate_dataset_dicts()` now accepts both `str` and `list[str]` as a source split value. This allows to merge different splits of same dataset.