### PR TITLE
`sciarg` dataset: fix `contradicts` is symmetric

### DIFF
--- a/dataset_builders/pie/sciarg/README.md
+++ b/dataset_builders/pie/sciarg/README.md
@@ -136,8 +136,8 @@ possibly since [Lauscher et al., 2018](https://aclanthology.org/W18-5206/) prese
 
 | Relations                  | Count | Percentage |
 | -------------------------- | ----: | ---------: |
-| support: `support`         |  5789 |     74.0 % |
-| attack: `contradict`       |   696 |      8.9 % |
+| support: `supports`        |  5789 |     74.0 % |
+| attack: `contradicts`      |   696 |      8.9 % |
 | other: `semantically_same` |    44 |      0.6 % |
 | other: `parts_of_same`     |  1298 |     16.6 % |
 | total                      |  7827 |    100.0 % |
@@ -146,17 +146,17 @@ possibly since [Lauscher et al., 2018](https://aclanthology.org/W18-5206/) prese
 
 | Relations                  | Count | Percentage |
 | -------------------------- | ----: | ---------: |
-| support: `support`         |  5788 |     88.7 % |
-| attack: `contradict`       |   696 |     10.7 % |
+| support: `supports`        |  5788 |     88.7 % |
+| attack: `contradicts`      |   696 |     10.7 % |
 | other: `semantically_same` |    44 |      0.7 % |
 | total                      |  6528 |    100.0 % |
 
 ##### Argumentative relations
 
-- `support`:
+- `supports`:
   - if the assumed veracity of *b* increases with the veracity of *a*
   - "Usually, this relationship exists from data to claim, but in many cases a claim might support another claim. Other combinations are still possible." -  (*Annotation Guidelines*, p. 3)
-- `contradict`:
+- `contradicts`:
   - if the assumed veracity of *b* decreases with the veracity of *a*
   - It is a **bi-directional**, i.e., symmetric relationship.
 

--- a/dataset_builders/pie/sciarg/sciarg.py
+++ b/dataset_builders/pie/sciarg/sciarg.py
@@ -35,7 +35,7 @@ def get_common_converter_pipeline_steps(target_document_type: type[Document]) ->
         trim_adus=TextSpanTrimmer(layer="labeled_spans"),
         sort_symmetric_relation_arguments=RelationArgumentSorter(
             relation_layer="binary_relations",
-            label_whitelist=["parts_of_same", "semantically_same"],
+            label_whitelist=["parts_of_same", "semantically_same", "contradicts"],
         ),
     )
 

--- a/tests/dataset_builders/pie/sciarg/test_sciarg.py
+++ b/tests/dataset_builders/pie/sciarg/test_sciarg.py
@@ -411,12 +411,12 @@ def test_converted_document(converted_document, dataset_variant):
                     ),
                 ),
                 (
-                    ("This approach is not commonly applied", "background_claim"),
-                    "contradicts",
                     (
                         "artists will edit the geometry of characters in the rest pose to fine-tune animations",
                         "background_claim",
                     ),
+                    "contradicts",
+                    ("This approach is not commonly applied", "background_claim"),
                 ),
                 (
                     (


### PR DESCRIPTION
Until now, it was missed that the `contradicts` relation is symmetric (see [SciArg guidelines](https://data.dws.informatik.uni-mannheim.de/sci-arg/annotation_guidelines.pdf), page 3). This PR adds the `contradicts` relations to the ones that get direction normalized. Note that this has only an effect to the converted dataset!

This also fixes the relation labels in some tables in the readme.