### PR TITLE
use `pie_modules.utils.sequence_tagging`

### DIFF
--- a/dataset_builders/pie/conll2003/conll2003.py
+++ b/dataset_builders/pie/conll2003/conll2003.py
@@ -1,12 +1,35 @@
 from dataclasses import dataclass
+from typing import List, Sequence, Tuple
 
 import datasets
+from pie_modules.utils.sequence_tagging import tag_sequence_to_token_spans
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.documents import TextDocument, TextDocumentWithLabeledSpans
-from pytorch_ie.utils.span import tokens_and_tags_to_text_and_labeled_spans
 
 from pie_datasets import GeneratorBasedBuilder
+
+
+def tokens_and_tags_to_text_and_labeled_spans(
+    tokens: Sequence[str], tags: Sequence[str]
+) -> Tuple[str, Sequence[LabeledSpan]]:
+    start = 0
+    token_offsets: List[Tuple[int, int]] = []
+    for token in tokens:
+        end = start + len(token)
+        token_offsets.append((start, end))
+        # we add a space after each token
+        start = end + 1
+
+    text = " ".join(tokens)
+
+    spans: List[LabeledSpan] = []
+    for label, (start, end) in tag_sequence_to_token_spans(tag_sequence=tags):
+        spans.append(
+            LabeledSpan(start=token_offsets[start][0], end=token_offsets[end][1], label=label)
+        )
+
+    return text, spans
 
 
 @dataclass

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,1 +1,3 @@
 pie-datasets>=0.8.1,<0.11.0
+# TODO: use release when available
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@main

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets>=0.8.1,<0.11.0
-# TODO: use release when available
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@main
+pie-modules>=0.15.4,<0.16.0

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,4 +1,2 @@
 pie-datasets>=0.6.0,<0.11.0
-# TODO: use release when available
-#pie-modules>=0.8.0,<0.12.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@main
+pie-modules>=0.15.4,<0.16.0

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,2 +1,4 @@
 pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.8.0,<0.12.0
+# TODO: use release when available
+#pie-modules>=0.8.0,<0.12.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@main

--- a/poetry.lock
+++ b/poetry.lock
@@ -1227,24 +1227,20 @@ xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "pie-modules"
-version = "0.15.3"
+version = "0.15.4"
 description = "Model and Taskmodule implementations for PyTorch-IE"
 optional = false
-python-versions = "^3.9"
-files = []
-develop = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "pie_modules-0.15.4-py3-none-any.whl", hash = "sha256:0d20d8579dbdc90cd5f66b4b0c2c80800377bb105daf6b8fcd3d6e9a585c14f4"},
+    {file = "pie_modules-0.15.4.tar.gz", hash = "sha256:2dbedb1ff3f64439c8c8816e9639cbe4e455fa3a253ef15b855f54528dced46d"},
+]
 
 [package.dependencies]
 pytorch-ie = ">=0.31.2,<0.32.0"
-pytorch-lightning = "^2.1.0"
-torchmetrics = "^1"
+pytorch-lightning = ">=2.1.0,<3.0.0"
+torchmetrics = ">=1,<2"
 transformers = ">=4.35.0,<4.37.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/ArneBinder/pie-modules.git"
-reference = "main"
-resolved_reference = "f0fc9c11013ba73456c9ac97eb32a647444e8173"
 
 [[package]]
 name = "platformdirs"
@@ -2462,4 +2458,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2a6b52fca532a10a22eda50347a1b65eaf5c13b18882e71aefa84b6e4278c06b"
+content-hash = "b0dd3c812ca7b850e5cad85966299972a483f70124cdd0729d3e51904ae5b609"

--- a/poetry.lock
+++ b/poetry.lock
@@ -273,20 +273,6 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -689,17 +675,6 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
-name = "joblib"
-version = "1.4.2"
-description = "Lightweight pipelining with Python functions"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
-    {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
-]
-
-[[package]]
 name = "lightning-utilities"
 version = "0.11.2"
 description = "Lightning toolbox for across the our ecosystem."
@@ -968,31 +943,6 @@ developer = ["changelist (==0.4)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"
 doc = ["nb2plots (>=0.7)", "nbconvert (<7.9)", "numpydoc (>=1.6)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.14)", "sphinx (>=7)", "sphinx-gallery (>=0.14)", "texext (>=0.6.7)"]
 extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.11)", "sympy (>=1.10)"]
 test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
-
-[[package]]
-name = "nltk"
-version = "3.8.1"
-description = "Natural Language Toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "nltk-3.8.1-py3-none-any.whl", hash = "sha256:fd5c9109f976fa86bcadba8f91e47f5e9293bd034474752e92a520f81c93dda5"},
-    {file = "nltk-3.8.1.zip", hash = "sha256:1834da3d0682cba4f2cede2f9aad6b0fafb6461ba451db0efb6f9c39798d64d3"},
-]
-
-[package.dependencies]
-click = "*"
-joblib = "*"
-regex = ">=2021.8.3"
-tqdm = "*"
-
-[package.extras]
-all = ["matplotlib", "numpy", "pyparsing", "python-crfsuite", "requests", "scikit-learn", "scipy", "twython"]
-corenlp = ["requests"]
-machine-learning = ["numpy", "python-crfsuite", "scikit-learn", "scipy"]
-plot = ["matplotlib"]
-tgrep = ["pyparsing"]
-twitter = ["twython"]
 
 [[package]]
 name = "nodeenv"
@@ -1277,23 +1227,24 @@ xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "pie-modules"
-version = "0.12.1"
+version = "0.15.3"
 description = "Model and Taskmodule implementations for PyTorch-IE"
 optional = false
-python-versions = "<4.0,>=3.9"
-files = [
-    {file = "pie_modules-0.12.1-py3-none-any.whl", hash = "sha256:bea5611e985b4ed44dd328d07cab26cdd3b5d3dcab794f132870e0e80fc2dd12"},
-    {file = "pie_modules-0.12.1.tar.gz", hash = "sha256:0647a337906b24b4ec083f94b9b8f58f8cbab57d782d0d89c8da6115a01486c7"},
-]
+python-versions = "^3.9"
+files = []
+develop = false
 
 [package.dependencies]
-networkx = ">=3.0.0,<4.0.0"
-nltk = ">=3.8.1,<4.0.0"
-pytorch-crf = ">=0.7.2"
-pytorch-ie = ">=0.31.0,<0.32.0"
-pytorch-lightning = ">=2.1.0,<3.0.0"
-torchmetrics = ">=1,<2"
+pytorch-ie = ">=0.31.2,<0.32.0"
+pytorch-lightning = "^2.1.0"
+torchmetrics = "^1"
 transformers = ">=4.35.0,<4.37.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/ArneBinder/pie-modules.git"
+reference = "main"
+resolved_reference = "f0fc9c11013ba73456c9ac97eb32a647444e8173"
 
 [[package]]
 name = "platformdirs"
@@ -1451,25 +1402,14 @@ files = [
 six = ">=1.5"
 
 [[package]]
-name = "pytorch-crf"
-version = "0.7.2"
-description = "Conditional random field in PyTorch"
-optional = false
-python-versions = ">=3.6, <4"
-files = [
-    {file = "pytorch-crf-0.7.2.tar.gz", hash = "sha256:e6456e22ccfc99a3d4fe1e03e996103b1b39e9830bf3c7e12e7a9077d3be866d"},
-    {file = "pytorch_crf-0.7.2-py3-none-any.whl", hash = "sha256:1b2d7d5eea3255f6e0cac09ab8b645472e76ff70d9333bc88762cf7317a4992d"},
-]
-
-[[package]]
 name = "pytorch-ie"
-version = "0.31.0"
+version = "0.31.7"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "pytorch_ie-0.31.0-py3-none-any.whl", hash = "sha256:d1149c0f866fb2de76421435e89bfe0143b27af11618e10d67f54fdffe95f8cd"},
-    {file = "pytorch_ie-0.31.0.tar.gz", hash = "sha256:16294458f07ecb5c1bb0c0bda3ab79740d4457dfcab5e2269dc747efa09893a6"},
+    {file = "pytorch_ie-0.31.7-py3-none-any.whl", hash = "sha256:1d4dc2ecbc929b0d4da99e2b39ccfe0a828535ac2fbf8eeb646c8540eac1a5a4"},
+    {file = "pytorch_ie-0.31.7.tar.gz", hash = "sha256:90660fd6db7f167dbce22ac09d5be74281ca1728ec24daf8e371f6d0606da53a"},
 ]
 
 [package.dependencies]
@@ -2522,4 +2462,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "deeb42e6abf47989c87e9616ecc3d9767ce9085e822a7eeea035ebd469efdb70"
+content-hash = "2a6b52fca532a10a22eda50347a1b65eaf5c13b18882e71aefa84b6e4278c06b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ numpy = "<2.0.0"
 pyarrow = "^13"
 
 [tool.poetry.group.dev.dependencies]
-pie-modules = ">=0.11.1,<0.13.0"
+# TODO: use pie-modules release 0.15.4 (including https://github.com/ArneBinder/pie-modules/pull/174) when available
+pie-modules = { git = "https://github.com/ArneBinder/pie-modules.git", branch = "main" }
 torch = [
     # default
     {version = "^2.1.0+cpu", source = "pytorch", markers = "sys_platform != 'darwin' or (platform_machine != 'arm64' and platform_machine != 'x86_64')"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ numpy = "<2.0.0"
 pyarrow = "^13"
 
 [tool.poetry.group.dev.dependencies]
-# TODO: use pie-modules release 0.15.4 (including https://github.com/ArneBinder/pie-modules/pull/174) when available
-pie-modules = { git = "https://github.com/ArneBinder/pie-modules.git", branch = "main" }
+pie-modules = ">=0.15.4,<0.16.0"
 torch = [
     # default
     {version = "^2.1.0+cpu", source = "pytorch", markers = "sys_platform != 'darwin' or (platform_machine != 'arm64' and platform_machine != 'x86_64')"},

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Union
 
 import pytest
+import torch
 from pytorch_ie import Document
 from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Union
 
 import pytest
-import torch
 from pytorch_ie import Document
 from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field


### PR DESCRIPTION
in `conll2003` and `scidtb_argmin` dataset loader to get rid of `pytorch-ie`. See #178 and https://github.com/ArneBinder/pie-core/issues/17 for context.

TODO:
 - [x] use release 0.15.4 (including https://github.com/ArneBinder/pie-modules/pull/174) when available