### PR TITLE
make document casting relaxed regarding annotation types

### DIFF
--- a/tests/unit/core/test_dataset_casting.py
+++ b/tests/unit/core/test_dataset_casting.py
@@ -231,8 +231,18 @@ def test_cast_document_type_rename_target_not_available(dataset_train):
         )
 
 
-def test_cast_document_type_rename_wrong_type(dataset_train):
+def test_cast_document_type_rename_wrong_annotation_type(dataset_train):
+
+    # works per default (uses keep_annotation_types=False internally)
+    casted = dataset_train.cast_document_type(
+        DocumentWithEntsWrongType, field_mapping={"entities": "ents"}
+    )
+    assert casted.document_type is DocumentWithEntsWrongType
+
+    # fails if keep_annotation_types=True
     with pytest.raises(ValueError, match=re.escape("new field is not the same as old field:")):
         dataset_train.cast_document_type(
-            DocumentWithEntsWrongType, field_mapping={"entities": "ents"}
+            DocumentWithEntsWrongType,
+            field_mapping={"entities": "ents"},
+            keep_annotation_types=True,
         )


### PR DESCRIPTION
This adds the parameter `keep_annotation_types` to `cast_document_type` (default: `False`) which is passed as new parameter `check_annotation_types` to `_check_fields_for_casting` (default: `True`). Only if `check_annotation_types`, an error will be raised in `_check_fields_for_casting` if the old an new layers do not match in field `type`, `default`, and `default_factory`. 

This is different than previous behavior, but since it is more relaxed now, we do **not** mark this PR as breaking. There is the slight risk, that some code relies on raising an error in the case of such a mismatch, but we take that (of what I am aware of, this is very unlikely). 

Context: This is required for #178 when casting Brat documents because they will use their own Brat specific annotation types in the future.