### PR TITLE
increase maximum allowed version of `pie-modules` for all individual datasets to `<0.16.0`

### DIFF
--- a/dataset_builders/pie/aae2/requirements.txt
+++ b/dataset_builders/pie/aae2/requirements.txt
@@ -1,2 +1,2 @@
 pie-datasets>=0.8.0,<0.11.0
-pie-modules>=0.8.3,<0.12.0
+pie-modules>=0.8.3,<0.16.0

--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,2 +1,2 @@
 pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.8.0,<0.12.0
+pie-modules>=0.8.0,<0.16.0

--- a/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
+++ b/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
@@ -1,1 +1,1 @@
-pie-datasets>=0.3.0
+pie-datasets>=0.3.0,<0.11.0

--- a/dataset_builders/pie/sciarg/requirements.txt
+++ b/dataset_builders/pie/sciarg/requirements.txt
@@ -1,3 +1,3 @@
 pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.10.8,<0.12.0
+pie-modules>=0.10.8,<0.16.0
 networkx>=3.0.0,<4.0.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,2 +1,2 @@
 pie-datasets>=0.8.1,<0.11.0
-pie-modules>=0.8.2,<0.12.0
+pie-modules>=0.8.2,<0.16.0

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,2 +1,2 @@
 pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.8.0,<0.12.0
+pie-modules>=0.8.0,<0.16.0

--- a/tests/dataset_builders/pie/abstrct/additional-requirements.txt
+++ b/tests/dataset_builders/pie/abstrct/additional-requirements.txt
@@ -1,1 +1,1 @@
-pie-modules>=0.10.3,<0.11.0    # to test tokenization
+pie-modules>=0.10.3,<0.16.0    # to test tokenization

--- a/tests/dataset_builders/pie/argmicro/additional-requirements.txt
+++ b/tests/dataset_builders/pie/argmicro/additional-requirements.txt
@@ -1,1 +1,1 @@
-pie-modules>=0.10.3,<0.11.0    # to test tokenization
+pie-modules>=0.10.3,<0.16.0    # to test tokenization

--- a/tests/dataset_builders/pie/drugprot/additional-requirements.txt
+++ b/tests/dataset_builders/pie/drugprot/additional-requirements.txt
@@ -1,1 +1,1 @@
-pie-modules>=0.10.3,<0.11.0    # to test tokenization
+pie-modules>=0.10.3,<0.16.0    # to test tokenization


### PR DESCRIPTION
This directly affects:
 - `aae2`
 - `cdcp`
 - `conll2012_ontonotesv5`
 - `sciarg`
 - `squad_v2`
 - `tacred`
 
and via test dependencies (for tokenization tests):
 - `abstract`
 - `argmicro`
 - `drugprot`