### PR TITLE
use `pie-core` in dataset builders

### DIFF
--- a/dataset_builders/pie/aae2/aae2.py
+++ b/dataset_builders/pie/aae2/aae2.py
@@ -2,9 +2,9 @@ import os
 from typing import Dict
 
 import pandas as pd
+from pie_modules.annotations import BinaryRelation
 from pie_modules.document.processing import RegexPartitioner
-from pytorch_ie.annotations import BinaryRelation
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextDocumentWithLabeledSpansAndBinaryRelations,
     TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )

--- a/dataset_builders/pie/aae2/requirements.txt
+++ b/dataset_builders/pie/aae2/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/aae2/requirements.txt
+++ b/dataset_builders/pie/aae2/requirements.txt
@@ -1,2 +1,3 @@
-pie-datasets>=0.8.0,<0.11.0
-pie-modules>=0.8.3,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/abstrct/abstrct.py
+++ b/dataset_builders/pie/abstrct/abstrct.py
@@ -1,4 +1,4 @@
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 
 from pie_datasets.builders import BratBuilder, BratConfig
 from pie_datasets.builders.brat import BratDocumentWithMergedSpans

--- a/dataset_builders/pie/abstrct/requirements.txt
+++ b/dataset_builders/pie/abstrct/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.4.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/abstrct/requirements.txt
+++ b/dataset_builders/pie/abstrct/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/argmicro/argmicro.py
+++ b/dataset_builders/pie/argmicro/argmicro.py
@@ -6,9 +6,9 @@ from itertools import combinations
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import datasets
-from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
-from pytorch_ie.core import Annotation, AnnotationList, annotation_field
-from pytorch_ie.documents import (
+from pie_core import Annotation, AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, Label, LabeledSpan, Span
+from pie_modules.documents import (
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,
 )
@@ -42,10 +42,10 @@ class MultiRelation(Annotation):
 @dataclasses.dataclass
 class ArgMicroDocument(TextBasedDocument):
     topic_id: Optional[str] = None
-    stance: AnnotationList[Label] = annotation_field()
-    edus: AnnotationList[Span] = annotation_field(target="text")
-    adus: AnnotationList[LabeledAnnotationCollection] = annotation_field(target="edus")
-    relations: AnnotationList[MultiRelation] = annotation_field(target="adus")
+    stance: AnnotationLayer[Label] = annotation_field()
+    edus: AnnotationLayer[Span] = annotation_field(target="text")
+    adus: AnnotationLayer[LabeledAnnotationCollection] = annotation_field(target="edus")
+    relations: AnnotationLayer[MultiRelation] = annotation_field(target="adus")
 
 
 def example_to_document(

--- a/dataset_builders/pie/argmicro/requirements.txt
+++ b/dataset_builders/pie/argmicro/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/argmicro/requirements.txt
+++ b/dataset_builders/pie/argmicro/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.3.3,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/biorel/biorel.py
+++ b/dataset_builders/pie/biorel/biorel.py
@@ -3,9 +3,9 @@ import logging
 from typing import Any
 
 import datasets
-from pytorch_ie import AnnotationLayer, annotation_field
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
-from pytorch_ie.documents import (
+from pie_core import AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
+from pie_modules.documents import (
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,
 )

--- a/dataset_builders/pie/biorel/requirements.txt
+++ b/dataset_builders/pie/biorel/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/biorel/requirements.txt
+++ b/dataset_builders/pie/biorel/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/brat/requirements.txt
+++ b/dataset_builders/pie/brat/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.4.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/brat/requirements.txt
+++ b/dataset_builders/pie/brat/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/cdcp/cdcp.py
+++ b/dataset_builders/pie/cdcp/cdcp.py
@@ -3,10 +3,10 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import datasets
+from pie_core import Annotation, AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan
 from pie_modules.document.processing.text_span_trimmer import trim_text_spans
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import Annotation, AnnotationList, annotation_field
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,
 )
@@ -32,9 +32,9 @@ class Attribute(Annotation):
 
 @dataclasses.dataclass
 class CDCPDocument(TextBasedDocument):
-    propositions: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="propositions")
-    urls: AnnotationList[Attribute] = annotation_field(target="propositions")
+    propositions: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="propositions")
+    urls: AnnotationLayer[Attribute] = annotation_field(target="propositions")
 
 
 def example_to_document(

--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,2 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.8.0,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/chemprot/chemprot.py
+++ b/dataset_builders/pie/chemprot/chemprot.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 import datasets
-from pytorch_ie import Document
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.documents import (
+from pie_core import Document
+from pie_modules.annotations import BinaryRelation, LabeledSpan
+from pie_modules.documents import (
     AnnotationLayer,
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,

--- a/dataset_builders/pie/chemprot/requirements.txt
+++ b/dataset_builders/pie/chemprot/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/chemprot/requirements.txt
+++ b/dataset_builders/pie/chemprot/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/comagc/comagc.py
+++ b/dataset_builders/pie/comagc/comagc.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import datasets
-from pytorch_ie import AnnotationLayer, Document, annotation_field
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_core import AnnotationLayer, Document, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 
 from pie_datasets import ArrowBasedBuilder
 

--- a/dataset_builders/pie/comagc/requirements.txt
+++ b/dataset_builders/pie/comagc/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/comagc/requirements.txt
+++ b/dataset_builders/pie/comagc/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/conll2003/conll2003.py
+++ b/dataset_builders/pie/conll2003/conll2003.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass
 from typing import List, Sequence, Tuple
 
 import datasets
+from pie_core import AnnotationLayer, annotation_field
+from pie_modules.annotations import LabeledSpan
+from pie_modules.documents import TextBasedDocument, TextDocumentWithLabeledSpans
 from pie_modules.utils.sequence_tagging import tag_sequence_to_token_spans
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextDocument, TextDocumentWithLabeledSpans
 
 from pie_datasets import GeneratorBasedBuilder
 
@@ -33,8 +33,8 @@ def tokens_and_tags_to_text_and_labeled_spans(
 
 
 @dataclass
-class CoNLL2003Document(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+class CoNLL2003Document(TextBasedDocument):
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 class Conll2003(GeneratorBasedBuilder):

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,2 +1,3 @@
-pie-datasets>=0.8.1,<0.11.0
-pie-modules>=0.15.4,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.15.4,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.15.4,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/conll2012_ontonotesv5/conll2012_ontonotesv5.py
+++ b/dataset_builders/pie/conll2012_ontonotesv5/conll2012_ontonotesv5.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
 import datasets
-from pytorch_ie.annotations import LabeledSpan, NaryRelation, Span
-from pytorch_ie.core import Annotation, AnnotationList, annotation_field
-from pytorch_ie.documents import (
+from pie_core import Annotation, AnnotationLayer, annotation_field
+from pie_modules.annotations import LabeledSpan, NaryRelation, Span
+from pie_modules.documents import (
     TextDocumentWithLabeledSpansAndLabeledPartitions,
     TokenBasedDocument,
 )
@@ -43,17 +43,17 @@ class Predicate(Span):
 @dataclasses.dataclass
 class Conll2012OntonotesV5Document(TokenBasedDocument):
     pos_tags: Optional[List[str]] = None
-    sentences: AnnotationList[Span] = annotation_field(target="tokens")
-    parse_trees: AnnotationList[Attribute] = annotation_field(target="sentences")
-    speakers: AnnotationList[Attribute] = annotation_field(target="sentences")
-    parts: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    coref_mentions: AnnotationList[Span] = annotation_field(target="tokens")
-    coref_clusters: AnnotationList[SpanSet] = annotation_field(target="coref_mentions")
-    srl_arguments: AnnotationList[Span] = annotation_field(target="tokens")
-    srl_relations: AnnotationList[NaryRelation] = annotation_field(target="srl_arguments")
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    predicates: AnnotationList[Predicate] = annotation_field(target="tokens")
-    word_senses: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+    sentences: AnnotationLayer[Span] = annotation_field(target="tokens")
+    parse_trees: AnnotationLayer[Attribute] = annotation_field(target="sentences")
+    speakers: AnnotationLayer[Attribute] = annotation_field(target="sentences")
+    parts: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    coref_mentions: AnnotationLayer[Span] = annotation_field(target="tokens")
+    coref_clusters: AnnotationLayer[SpanSet] = annotation_field(target="coref_mentions")
+    srl_arguments: AnnotationLayer[Span] = annotation_field(target="tokens")
+    srl_relations: AnnotationLayer[NaryRelation] = annotation_field(target="srl_arguments")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    predicates: AnnotationLayer[Predicate] = annotation_field(target="tokens")
+    word_senses: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
 
 def bio2spans(bio: List[str], offset: int = 0) -> List[LabeledSpan]:

--- a/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
+++ b/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
+++ b/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.3.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/drugprot/drugprot.py
+++ b/dataset_builders/pie/drugprot/drugprot.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
 import datasets
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.documents import (
+from pie_modules.annotations import BinaryRelation, LabeledSpan
+from pie_modules.documents import (
     AnnotationLayer,
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,

--- a/dataset_builders/pie/drugprot/requirements.txt
+++ b/dataset_builders/pie/drugprot/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/drugprot/requirements.txt
+++ b/dataset_builders/pie/drugprot/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.9.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/imdb/imdb.py
+++ b/dataset_builders/pie/imdb/imdb.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 import datasets
-from pytorch_ie.annotations import Label
-from pytorch_ie.documents import TextDocumentWithLabel
+from pie_modules.annotations import Label
+from pie_modules.documents import TextDocumentWithLabel
 
 from pie_datasets import GeneratorBasedBuilder
 

--- a/dataset_builders/pie/imdb/requirements.txt
+++ b/dataset_builders/pie/imdb/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/imdb/requirements.txt
+++ b/dataset_builders/pie/imdb/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.8.1,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/sciarg/requirements.txt
+++ b/dataset_builders/pie/sciarg/requirements.txt
@@ -1,4 +1,3 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0
 networkx>=3.0.0,<4.0.0

--- a/dataset_builders/pie/sciarg/requirements.txt
+++ b/dataset_builders/pie/sciarg/requirements.txt
@@ -1,3 +1,4 @@
-pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.10.8,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
 networkx>=3.0.0,<4.0.0

--- a/dataset_builders/pie/sciarg/sciarg.py
+++ b/dataset_builders/pie/sciarg/sciarg.py
@@ -1,14 +1,15 @@
+import dataclasses
 import logging
 from typing import Union
 
+from pie_core import AnnotationLayer, Document, annotation_field
 from pie_modules.document.processing import (
     RegexPartitioner,
     RelationArgumentSorter,
     SpansViaRelationMerger,
     TextSpanTrimmer,
 )
-from pytorch_ie.core import Document
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextDocumentWithLabeledMultiSpansAndBinaryRelations,
     TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions,
     TextDocumentWithLabeledSpansAndBinaryRelations,
@@ -16,7 +17,12 @@ from pytorch_ie.documents import (
 )
 
 from pie_datasets.builders import BratBuilder, BratConfig
-from pie_datasets.builders.brat import BratDocument, BratDocumentWithMergedSpans
+from pie_datasets.builders.brat import (
+    BratAttribute,
+    BratDocument,
+    BratDocumentWithMergedSpans,
+    BratNote,
+)
 from pie_datasets.core.dataset import DocumentConvertersType
 from pie_datasets.document.processing import Caster, Pipeline
 
@@ -24,6 +30,35 @@ logger = logging.getLogger(__name__)
 
 URL = "http://data.dws.informatik.uni-mannheim.de/sci-arg/compiled_corpus.zip"
 SPLIT_PATHS = {"train": "compiled_corpus"}
+
+
+@dataclasses.dataclass
+class ConvertedBratDocument(TextDocumentWithLabeledMultiSpansAndBinaryRelations):
+    span_attributes: AnnotationLayer[BratAttribute] = annotation_field(
+        target="labeled_multi_spans"
+    )
+    relation_attributes: AnnotationLayer[BratAttribute] = annotation_field(
+        target="binary_relations"
+    )
+    notes: AnnotationLayer[BratNote] = annotation_field(
+        targets=[
+            "labeled_multi_spans",
+            "binary_relations",
+            "span_attributes",
+            "relation_attributes",
+        ]
+    )
+
+
+@dataclasses.dataclass
+class ConvertedBratDocumentWithMergedSpans(TextDocumentWithLabeledSpansAndBinaryRelations):
+    span_attributes: AnnotationLayer[BratAttribute] = annotation_field(target="labeled_spans")
+    relation_attributes: AnnotationLayer[BratAttribute] = annotation_field(
+        target="binary_relations"
+    )
+    notes: AnnotationLayer[BratNote] = annotation_field(
+        targets=["labeled_spans", "binary_relations", "span_attributes", "relation_attributes"]
+    )
 
 
 def get_common_converter_pipeline_steps(target_document_type: type[Document]) -> dict:
@@ -106,13 +141,36 @@ class SciArg(BratBuilder):
     def _generate_document(self, example, **kwargs):
         document = super()._generate_document(example, **kwargs)
         if self.config.resolve_parts_of_same:
-            document = SpansViaRelationMerger(
-                relation_layer="relations",
+            # we need to convert the document to a different type to be able to merge the spans:
+            # SpansViaRelationMerger expects the spans to be of type LabeledSpan,
+            # but the document has spans of type BratSpan
+            converted_doc = document.as_type(
+                ConvertedBratDocumentWithMergedSpans,
+                field_mapping={
+                    "spans": "labeled_spans",
+                    "relations": "binary_relations",
+                },
+                keep_remaining=True,
+            )
+            merged_document = SpansViaRelationMerger(
+                relation_layer="binary_relations",
                 link_relation_label="parts_of_same",
                 create_multi_spans=True,
-                result_document_type=BratDocument,
-                result_field_mapping={"spans": "spans", "relations": "relations"},
-            )(document)
+                result_document_type=ConvertedBratDocument,
+                result_field_mapping={
+                    "labeled_spans": "labeled_multi_spans",
+                    "binary_relations": "binary_relations",
+                    "span_attributes": "span_attributes",
+                    "relation_attributes": "relation_attributes",
+                    "notes": "notes",
+                },
+            )(converted_doc)
+            # convert back to BratDocument
+            document = merged_document.as_type(
+                BratDocument,
+                field_mapping={"labeled_multi_spans": "spans", "binary_relations": "relations"},
+                keep_remaining=True,
+            )
         else:
             # some documents have duplicate relations, remove them
             remove_duplicate_relations(document)

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.15.4,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,2 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.15.4,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.15.4,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/scidtb_argmin/scidtb_argmin.py
+++ b/dataset_builders/pie/scidtb_argmin/scidtb_argmin.py
@@ -3,16 +3,16 @@ import logging
 from typing import Any, Dict
 
 import datasets
+from pie_core import AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan
 from pie_modules.document.processing import token_based_document_to_text_based
+from pie_modules.documents import (
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+    TokenBasedDocument,
+)
 from pie_modules.utils.sequence_tagging import (
     tag_sequence_to_token_spans,
     token_spans_to_tag_sequence,
-)
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import (
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-    TokenBasedDocument,
 )
 
 from pie_datasets import GeneratorBasedBuilder
@@ -22,14 +22,14 @@ log = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class SciDTBArgminDocument(TokenBasedDocument):
-    units: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="units")
+    units: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="units")
 
 
 @dataclasses.dataclass
 class SimplifiedSciDTBArgminDocument(TokenBasedDocument):
-    labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(target="labeled_spans")
+    labeled_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="labeled_spans")
 
 
 def example_to_document(

--- a/dataset_builders/pie/scientific_papers/requirements.txt
+++ b/dataset_builders/pie/scientific_papers/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/scientific_papers/requirements.txt
+++ b/dataset_builders/pie/scientific_papers/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.8.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/scientific_papers/scientific_papers.py
+++ b/dataset_builders/pie/scientific_papers/scientific_papers.py
@@ -2,13 +2,8 @@ import dataclasses
 from typing import Any, Dict, List
 
 import datasets
-from pytorch_ie.core import (
-    Annotation,
-    AnnotationLayer,
-    AnnotationList,
-    annotation_field,
-)
-from pytorch_ie.documents import TextBasedDocument
+from pie_core import Annotation, AnnotationLayer, annotation_field
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder
 
@@ -38,7 +33,7 @@ class ScientificPapersDocument(TextBasedDocument):
     """A PIE document for scientific papers dataset."""
 
     abstract: AnnotationLayer[AbstractiveSummary] = annotation_field()
-    section_names: AnnotationList[SectionName] = annotation_field()
+    section_names: AnnotationLayer[SectionName] = annotation_field()
 
 
 def example_to_document(

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,2 +1,3 @@
-pie-datasets>=0.8.1,<0.11.0
-pie-modules>=0.8.2,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,2 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
-pie-modules>=0.8.0,<0.16.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/tacred/tacred.py
+++ b/dataset_builders/pie/tacred/tacred.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 import datasets
+from pie_core import Annotation, AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan
 from pie_modules.document.processing import token_based_document_to_text_based
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import Annotation, AnnotationList, annotation_field
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextDocumentWithLabeledSpansAndBinaryRelations,
     TokenBasedDocument,
 )
@@ -29,17 +29,17 @@ class TokenAttribute(Annotation):
 
 @dataclass
 class TacredDocument(TokenBasedDocument):
-    stanford_ner: AnnotationList[TokenAttribute] = annotation_field(target="tokens")
-    stanford_pos: AnnotationList[TokenAttribute] = annotation_field(target="tokens")
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
-    dependency_relations: AnnotationList[TokenRelation] = annotation_field(target="tokens")
+    stanford_ner: AnnotationLayer[TokenAttribute] = annotation_field(target="tokens")
+    stanford_pos: AnnotationLayer[TokenAttribute] = annotation_field(target="tokens")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
+    dependency_relations: AnnotationLayer[TokenRelation] = annotation_field(target="tokens")
 
 
 @dataclass
 class SimpleTacredDocument(TokenBasedDocument):
-    labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(target="labeled_spans")
+    labeled_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="labeled_spans")
 
 
 def example_to_document(

--- a/dataset_builders/pie/tbga/requirements.txt
+++ b/dataset_builders/pie/tbga/requirements.txt
@@ -1,3 +1,2 @@
 pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
-#pie-modules>=0.13.5,<0.16.0
-pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core
+pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/tbga/requirements.txt
+++ b/dataset_builders/pie/tbga/requirements.txt
@@ -1,1 +1,3 @@
-pie-datasets>=0.6.0,<0.11.0
+pie-datasets @ git+https://github.com/ArneBinder/pie-datasets@use_pie_core
+#pie-modules>=0.13.5,<0.16.0
+pie-modules @ git+https://github.com/ArneBinder/pie-modules@use_pie_core

--- a/dataset_builders/pie/tbga/tbga.py
+++ b/dataset_builders/pie/tbga/tbga.py
@@ -2,9 +2,9 @@ import dataclasses
 from typing import Any
 
 import datasets
-from pytorch_ie import AnnotationLayer, annotation_field
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
-from pytorch_ie.documents import (
+from pie_core import AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
+from pie_modules.documents import (
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,
 )

--- a/tests/dataset_builders/common.py
+++ b/tests/dataset_builders/common.py
@@ -6,9 +6,9 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TokenBasedDocument
+from pie_core import AnnotationLayer, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledSpan
+from pie_modules.documents import TokenBasedDocument
 
 from tests import FIXTURES_ROOT
 
@@ -77,17 +77,17 @@ def _load_json(fn: str):
 
 @dataclasses.dataclass
 class TestTokenDocumentWithLabeledSpans(TokenBasedDocument):
-    labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+    labeled_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
 
 @dataclasses.dataclass
 class TestTokenDocumentWithLabeledSpansAndBinaryRelations(TestTokenDocumentWithLabeledSpans):
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(target="labeled_spans")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="labeled_spans")
 
 
 @dataclasses.dataclass
 class TestTokenDocumentWithLabeledPartitions(TokenBasedDocument):
-    labeled_partitions: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+    labeled_partitions: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
 
 @dataclasses.dataclass

--- a/tests/dataset_builders/pie/aae2/test_aae2.py
+++ b/tests/dataset_builders/pie/aae2/test_aae2.py
@@ -2,10 +2,10 @@ from typing import List
 
 import pytest
 from datasets import disable_caching
+from pie_core import Document
+from pie_modules.annotations import BinaryRelation, LabeledSpan
 from pie_modules.document.processing import tokenize_document
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import Document
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextDocumentWithLabeledSpansAndBinaryRelations,
     TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
@@ -17,7 +17,11 @@ from dataset_builders.pie.aae2.aae2 import (
     remove_cross_partition_relations,
 )
 from pie_datasets import DatasetDict
-from pie_datasets.builders.brat import BratAttribute, BratDocumentWithMergedSpans
+from pie_datasets.builders.brat import (
+    BratAttribute,
+    BratDocumentWithMergedSpans,
+    BratSpan,
+)
 from tests.dataset_builders.common import (
     PIE_BASE_PATH,
     TestTokenDocumentWithLabeledSpansAndBinaryRelations,
@@ -170,9 +174,9 @@ def test_convert_aae2_claim_attributions_to_relations(method):
         text="This is an example claim. This is the first major claim. "
         "This is the second major claim."
     )
-    claim = LabeledSpan(start=0, end=25, label="Claim")
-    first_majorclaim = LabeledSpan(start=26, end=56, label="MajorClaim")
-    second_majorclaim = LabeledSpan(start=57, end=88, label="MajorClaim")
+    claim = BratSpan(start=0, end=25, label="Claim")
+    first_majorclaim = BratSpan(start=26, end=56, label="MajorClaim")
+    second_majorclaim = BratSpan(start=57, end=88, label="MajorClaim")
     sample_doc.spans.extend([claim, first_majorclaim, second_majorclaim])
     # sanity check (works only after labeled spans were added to the document)
     assert str(claim) == "This is an example claim."

--- a/tests/dataset_builders/pie/abstrct/additional-requirements.txt
+++ b/tests/dataset_builders/pie/abstrct/additional-requirements.txt
@@ -1,1 +1,0 @@
-pie-modules>=0.10.3,<0.16.0    # to test tokenization

--- a/tests/dataset_builders/pie/abstrct/test_abstrct.py
+++ b/tests/dataset_builders/pie/abstrct/test_abstrct.py
@@ -2,9 +2,9 @@ from typing import List
 
 import pytest
 from datasets import disable_caching
+from pie_core import Document
 from pie_modules.document.processing import tokenize_document
-from pytorch_ie.core import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from dataset_builders.pie.abstrct.abstrct import AbstRCT

--- a/tests/dataset_builders/pie/argmicro/additional-requirements.txt
+++ b/tests/dataset_builders/pie/argmicro/additional-requirements.txt
@@ -1,1 +1,0 @@
-pie-modules>=0.10.3,<0.16.0    # to test tokenization

--- a/tests/dataset_builders/pie/argmicro/test_argmicro.py
+++ b/tests/dataset_builders/pie/argmicro/test_argmicro.py
@@ -4,9 +4,9 @@ from typing import List
 
 import pytest
 from datasets import disable_caching, load_dataset
+from pie_core import Document
 from pie_modules.document.processing import tokenize_document
-from pytorch_ie.core import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from dataset_builders.pie.argmicro.argmicro import (

--- a/tests/dataset_builders/pie/biorel/test_biorel.py
+++ b/tests/dataset_builders/pie/biorel/test_biorel.py
@@ -1,13 +1,11 @@
-import datasets
 import pytest
 from datasets import disable_caching, load_dataset
-from pytorch_ie import Document
+from pie_core import Document
 
 from dataset_builders.pie.biorel.biorel import (
     BioRel,
     BioRelDocument,
     convert_to_text_document_with_labeled_spans_and_binary_relations,
-    document_to_example,
     example_to_document,
 )
 from pie_datasets import IterableDataset

--- a/tests/dataset_builders/pie/cdcp/test_cdcp.py
+++ b/tests/dataset_builders/pie/cdcp/test_cdcp.py
@@ -3,10 +3,10 @@ from typing import List
 
 import pytest
 from datasets import disable_caching, load_dataset
+from pie_core import AnnotationLayer, Document, annotation_field
+from pie_modules.annotations import LabeledSpan
 from pie_modules.document.processing import tokenize_document
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, Document, annotation_field
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextBasedDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,
 )
@@ -186,7 +186,7 @@ def _assert_no_span_overlap(document: Document, text_field: str, span_layer: str
 def test_assert_no_span_overlap():
     @dataclasses.dataclass
     class TextDocumentWithEntities(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     doc0 = TextDocumentWithEntities(text="abcdefghijklmnop")
     doc0.entities.append(LabeledSpan(start=0, end=4, label="A"))

--- a/tests/dataset_builders/pie/chemprot/test_chemprot.py
+++ b/tests/dataset_builders/pie/chemprot/test_chemprot.py
@@ -2,8 +2,8 @@ from typing import Union
 
 import datasets
 import pytest
-from pytorch_ie import Document
-from pytorch_ie.documents import (
+from pie_core import Document
+from pie_modules.documents import (
     TextDocumentWithLabeledSpansAndBinaryRelations,
     TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )

--- a/tests/dataset_builders/pie/comagc/test_comagc.py
+++ b/tests/dataset_builders/pie/comagc/test_comagc.py
@@ -1,7 +1,7 @@
 import datasets
 import pytest
-from pytorch_ie import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_core import Document
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 
 from dataset_builders.pie.comagc.comagc import (
     Comagc,

--- a/tests/dataset_builders/pie/conll2003/test_conll2003.py
+++ b/tests/dataset_builders/pie/conll2003/test_conll2003.py
@@ -1,7 +1,7 @@
 import datasets
 import pytest
-from pytorch_ie.core import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpans
+from pie_core import Document
+from pie_modules.documents import TextDocumentWithLabeledSpans
 
 from dataset_builders.pie.conll2003.conll2003 import Conll2003
 from pie_datasets import DatasetDict

--- a/tests/dataset_builders/pie/conll2012_ontonotesv5/test_conll2012_ontonotesv5.py
+++ b/tests/dataset_builders/pie/conll2012_ontonotesv5/test_conll2012_ontonotesv5.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from datasets import disable_caching, load_dataset
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndLabeledPartitions
+from pie_modules.documents import TextDocumentWithLabeledSpansAndLabeledPartitions
 
 from dataset_builders.pie.conll2012_ontonotesv5.conll2012_ontonotesv5 import (
     Conll2012Ontonotesv5,

--- a/tests/dataset_builders/pie/drugprot/additional-requirements.txt
+++ b/tests/dataset_builders/pie/drugprot/additional-requirements.txt
@@ -1,1 +1,0 @@
-pie-modules>=0.10.3,<0.16.0    # to test tokenization

--- a/tests/dataset_builders/pie/imdb/test_imdb.py
+++ b/tests/dataset_builders/pie/imdb/test_imdb.py
@@ -1,7 +1,7 @@
 import datasets
 import pytest
 from datasets import disable_caching, load_dataset
-from pytorch_ie.core import Document
+from pie_core import Document
 
 from dataset_builders.pie.imdb.imdb import Imdb
 from pie_datasets import Dataset, IterableDataset

--- a/tests/dataset_builders/pie/sciarg/test_sciarg.py
+++ b/tests/dataset_builders/pie/sciarg/test_sciarg.py
@@ -4,10 +4,10 @@ from typing import Any, List, Optional, Sequence, Type
 
 import datasets
 import pytest
+from pie_core import Annotation, AnnotationLayer, Document, annotation_field
+from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan, Span
 from pie_modules.document.processing import tokenize_document
-from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan, Span
-from pytorch_ie.core import Annotation, AnnotationLayer, Document, annotation_field
-from pytorch_ie.documents import (
+from pie_modules.documents import (
     TextDocumentWithLabeledMultiSpansAndBinaryRelations,
     TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions,
     TextDocumentWithLabeledPartitions,
@@ -23,6 +23,9 @@ from pie_datasets.builders.brat import (
     BratAttribute,
     BratDocument,
     BratDocumentWithMergedSpans,
+    BratMultiSpan,
+    BratRelation,
+    BratSpan,
 )
 from tests.dataset_builders.common import (
     PIE_BASE_PATH,
@@ -76,14 +79,14 @@ LABELED_PARTITION_COUNTS = {"Abstract": 40, "H1": 340, "Title": 40}
 def resolve_annotation(annotation: Annotation) -> Any:
     if annotation.target is None:
         return None
-    if isinstance(annotation, LabeledSpan):
+    if isinstance(annotation, (LabeledSpan, BratSpan)):
         return annotation.target[annotation.start : annotation.end], annotation.label
-    elif isinstance(annotation, LabeledMultiSpan):
+    elif isinstance(annotation, (LabeledMultiSpan, BratMultiSpan)):
         return (
             tuple(annotation.target[start:end] for start, end in annotation.slices),
             annotation.label,
         )
-    elif isinstance(annotation, BinaryRelation):
+    elif isinstance(annotation, (BinaryRelation, BratRelation)):
         return (
             resolve_annotation(annotation.head),
             annotation.label,
@@ -109,13 +112,13 @@ def sort_annotations(annotations: Sequence[Annotation]) -> List[Annotation]:
     if len(annotations) == 0:
         return []
     annotation = annotations[0]
-    if isinstance(annotation, LabeledSpan):
+    if isinstance(annotation, (LabeledSpan, BratSpan)):
         return sorted(annotations, key=lambda a: (a.start, a.end, a.label))
     elif isinstance(annotation, Span):
         return sorted(annotations, key=lambda a: (a.start, a.end))
-    elif isinstance(annotation, LabeledMultiSpan):
+    elif isinstance(annotation, (LabeledMultiSpan, BratMultiSpan)):
         return sorted(annotations, key=lambda a: (a.slices, a.label))
-    elif isinstance(annotation, BinaryRelation):
+    elif isinstance(annotation, (BinaryRelation, BratRelation)):
         if isinstance(annotation.head, LabeledSpan) and isinstance(annotation.tail, LabeledSpan):
             return sorted(
                 annotations,

--- a/tests/dataset_builders/pie/scidtb_argmin/test_scidtb_argmin.py
+++ b/tests/dataset_builders/pie/scidtb_argmin/test_scidtb_argmin.py
@@ -3,9 +3,9 @@ from typing import List
 
 import pytest
 from datasets import disable_caching, load_dataset
+from pie_core import Document
 from pie_modules.document.processing import tokenize_document
-from pytorch_ie.core import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from dataset_builders.pie.scidtb_argmin.scidtb_argmin import (

--- a/tests/dataset_builders/pie/squad_v2/test_squad_v2.py
+++ b/tests/dataset_builders/pie/squad_v2/test_squad_v2.py
@@ -1,7 +1,7 @@
 import datasets
 import pytest
+from pie_core import Document
 from pie_modules.documents import ExtractiveQADocument
-from pytorch_ie.core import Document
 
 from dataset_builders.pie.squad_v2.squad_v2 import SquadV2
 from pie_datasets import Dataset, IterableDataset, load_dataset

--- a/tests/dataset_builders/pie/tacred/test_tacred.py
+++ b/tests/dataset_builders/pie/tacred/test_tacred.py
@@ -3,8 +3,8 @@ import os
 
 import pytest
 from datasets import ClassLabel, load_dataset
-from pytorch_ie.core import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pie_core import Document
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 
 from dataset_builders.pie.tacred.tacred import (
     Tacred,

--- a/tests/dataset_builders/pie/tbga/test_tbga.py
+++ b/tests/dataset_builders/pie/tbga/test_tbga.py
@@ -1,6 +1,6 @@
 import pytest
 from datasets import disable_caching, load_dataset
-from pytorch_ie import Document
+from pie_core import Document
 
 from dataset_builders.pie.tbga.tbga import (
     Tbga,


### PR DESCRIPTION
This PR is the follow-up of #178. This is **not breaking** since the versioning of the dataset builders (this PR causes indeed breaking changes for some) is not handled by the `pie-dataset`, but rather via `revision`s on the Huggingface Hub. 

requires: 
 - [x] release of `pie-modules` including https://github.com/ArneBinder/pie-modules/pull/176
 - [x] release of `pie-datasets` including #178

TODO: for all individual dataset loaders and respective tests
 - [x] switch to versions of `pie-modules` and `pie-datasets` that use `pie-core` 
 - [x] use `Annotation`, `Document`, etc. from `pie-core` (use `AnnotationLayer` instead if `AnnotationList`)
 - [x] use annotations, documents, etc from `pie-modules`
 - [ ] switch to releases of `pie-modules` and `pie-datasets` when available

context: https://github.com/ArneBinder/pie-core/issues/17