### PR TITLE
make `dev` dependencies optional

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -48,7 +48,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --with dev --no-interaction --no-root
 
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -51,7 +51,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --with dev --no-interaction --no-root
 
       #----------------------------------------------
       # find and list modified files

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --with dev --no-interaction --no-root
 
       #----------------------------------------------
       # install your root project, if required

--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ load the dataset with `pie_datasets.load_dataset`, the script has to be located 
    git clone https://github.com/ArneBinder/pie-datasets
    cd pie-datasets
    ```
-3. Create a virtual environment and install the dependencies:
+3. Create a virtual environment and install the dependencies (including development dependencies):
    ```bash
-   poetry install
+   poetry install --with dev
    ```
 
 Finally, to run any of the below commands, you need to activate the virtual environment:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2458,4 +2458,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b0dd3c812ca7b850e5cad85966299972a483f70124cdd0729d3e51904ae5b609"
+content-hash = "8d93ec800756a4631adf47e5c6218b28dcfbd1eb2723fa2f30d5b957446464c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ numpy = "<2.0.0"
 # this was manually added because we get a conflict with pyarrow otherwise
 pyarrow = "^13"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 pie-modules = ">=0.15.4,<0.16.0"
 torch = [


### PR DESCRIPTION
The `dev` dependencies should not be installed per default in any packages that require `pie-datasets`.

After this, it is required to install via `poetry install --with dev` for development purposes, e.g., any testing etc. (this is also reflected in the [README.md](https://github.com/ArneBinder/pie-datasets/blob/main/README.md#development)).