### PR TITLE
add parameter `mode` to `DatasetDict.to_json`

### DIFF
--- a/src/pie_datasets/core/dataset_dict.py
+++ b/src/pie_datasets/core/dataset_dict.py
@@ -195,7 +195,7 @@ class DatasetDict(datasets.DatasetDict):
 
         Args:
             path: path to the output directory
-            mode: mode for writing the data. Can be either "a" (append) or "w" (overwrite).
+            mode: mode for writing the data. Can be either "a" (append) or "w" (overwrite). Default is "a".
             **kwargs: additional keyword arguments for `json.dump()`
         """
 

--- a/src/pie_datasets/core/dataset_dict.py
+++ b/src/pie_datasets/core/dataset_dict.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
@@ -187,13 +188,14 @@ class DatasetDict(datasets.DatasetDict):
             hf_dataset = {split: hf_dataset}
         return cls.from_hf(hf_dataset, document_type=document_type)
 
-    def to_json(self, path: Union[str, Path], **kwargs) -> None:
+    def to_json(self, path: Union[str, Path], mode: str = "a", **kwargs) -> None:
         """Serializes the DatasetDict. We convert all documents with `.asdict()` and dump them with
         `json.dump()` to one JSONLINE file per split. If there is already serialized data in the
         output directory, we append the new data to the existing files.
 
         Args:
             path: path to the output directory
+            mode: mode for writing the data. Can be either "a" (append) or "w" (overwrite).
             **kwargs: additional keyword arguments for `json.dump()`
         """
 
@@ -201,22 +203,37 @@ class DatasetDict(datasets.DatasetDict):
 
         # save the metadata
         metadata = {"document_type": serialize_document_type(self.document_type)}
-        os.makedirs(path, exist_ok=True)
-        if os.path.exists(path / METADATA_FILE_NAME):
-            # load previous metadata
-            with open(path / METADATA_FILE_NAME) as f:
-                previous_metadata = json.load(f)
-            if previous_metadata != metadata:
-                raise ValueError(
-                    f"The metadata file {path / METADATA_FILE_NAME} already exists, "
-                    "but the content does not match the current metadata. Can not append "
-                    "the current dataset to already serialized data."
-                    f"\nprevious metadata: {previous_metadata}"
-                    f"\ncurrent metadata: {metadata}"
+
+        if mode == "a":
+            os.makedirs(path, exist_ok=True)
+            if os.path.exists(path / METADATA_FILE_NAME):
+                # load previous metadata
+                with open(path / METADATA_FILE_NAME) as f:
+                    previous_metadata = json.load(f)
+                if previous_metadata != metadata:
+                    raise ValueError(
+                        f"The metadata file {path / METADATA_FILE_NAME} already exists, "
+                        "but the content does not match the current metadata. Can not append "
+                        "the current dataset to already serialized data."
+                        f"\nprevious metadata: {previous_metadata}"
+                        f"\ncurrent metadata: {metadata}"
+                    )
+            else:
+                with open(path / METADATA_FILE_NAME, "w") as f:
+                    json.dump(metadata, f, indent=2)
+        elif mode == "w":
+            # clear the output directory if it exists (via shutils)
+            if os.path.exists(path):
+                logger.warning(
+                    f'Dataset serialization directory "{path}" already exists, removing it to overwrite existing files.'
                 )
-        else:
+                shutil.rmtree(path)
+            os.makedirs(path, exist_ok=True)
+
             with open(path / METADATA_FILE_NAME, "w") as f:
                 json.dump(metadata, f, indent=2)
+        else:
+            raise ValueError(f"mode must be 'a' (append) or 'w' (overwrite), but is {mode}.")
 
         # save the splits
         for split, dataset in self.items():
@@ -224,8 +241,8 @@ class DatasetDict(datasets.DatasetDict):
             logger.info(f'serialize documents to "{split_path}" ...')
             os.makedirs(split_path, exist_ok=True)
             file_name = split_path / "documents.jsonl"
-            mode = "a" if os.path.exists(file_name) else "w"
-            with open(file_name, mode) as f:
+            write_mode = "a" if os.path.exists(file_name) else "w"
+            with open(file_name, write_mode) as f:
                 for doc in dataset:
                     f.write(json.dumps(doc.asdict(), **kwargs) + "\n")
 

--- a/src/pie_datasets/core/dataset_dict.py
+++ b/src/pie_datasets/core/dataset_dict.py
@@ -233,7 +233,7 @@ class DatasetDict(datasets.DatasetDict):
             with open(path / METADATA_FILE_NAME, "w") as f:
                 json.dump(metadata, f, indent=2)
         else:
-            raise ValueError(f"mode must be 'a' (append) or 'w' (overwrite), but is {mode}.")
+            raise ValueError(f'mode must be "a" (append) or "w" (overwrite), but is "{mode}".')
 
         # save the splits
         for split, dataset in self.items():

--- a/tests/unit/core/test_dataset_dict.py
+++ b/tests/unit/core/test_dataset_dict.py
@@ -184,6 +184,17 @@ def test_to_json_and_back_append_metadata_mismatch(dataset_dict, tmp_path):
     )
 
 
+def test_to_json_unknown_mode(dataset_dict, tmp_path):
+    path = Path(tmp_path) / "dataset_dict"
+
+    with pytest.raises(ValueError) as excinfo:
+        dataset_dict.to_json(path, mode="unknown_mode")
+    assert (
+        str(excinfo.value)
+        == 'mode must be "a" (append) or "w" (overwrite), but is "unknown_mode".'
+    )
+
+
 def test_document_type_empty_no_splits():
     with pytest.raises(ValueError) as excinfo:
         DatasetDict().document_type

--- a/tests/unit/core/test_dataset_dict.py
+++ b/tests/unit/core/test_dataset_dict.py
@@ -114,7 +114,7 @@ def test_to_json_and_back_serialize_document_type(dataset_dict, tmp_path):
             assert doc1 == doc2
 
 
-def test_to_json_and_back_append(dataset_dict, tmp_path):
+def test_to_json_and_back_append(dataset_dict, tmp_path, caplog):
     path = Path(tmp_path) / "dataset_dict"
 
     dataset_dict1 = DatasetDict(
@@ -123,8 +123,10 @@ def test_to_json_and_back_append(dataset_dict, tmp_path):
     dataset_dict2 = DatasetDict(
         {split_name: Dataset.from_documents(docs[2:]) for split_name, docs in dataset_dict.items()}
     )
+    caplog.clear()
     dataset_dict1.to_json(path)
     dataset_dict2.to_json(path)
+    assert len(caplog.messages) == 0
     dataset_dict_from_json = DatasetDict.from_json(
         data_dir=str(path),
     )
@@ -132,6 +134,32 @@ def test_to_json_and_back_append(dataset_dict, tmp_path):
     for split in dataset_dict:
         assert len(dataset_dict_from_json[split]) == len(dataset_dict[split])
         for doc1, doc2 in zip(dataset_dict_from_json[split], dataset_dict[split]):
+            assert doc1 == doc2
+
+
+def test_to_json_and_back_append_overwrite(dataset_dict, tmp_path, caplog):
+    path = Path(tmp_path) / "dataset_dict"
+
+    dataset_dict1 = DatasetDict(
+        {split_name: Dataset.from_documents(docs[:2]) for split_name, docs in dataset_dict.items()}
+    )
+    dataset_dict2 = DatasetDict(
+        {split_name: Dataset.from_documents(docs[2:]) for split_name, docs in dataset_dict.items()}
+    )
+    caplog.clear()
+    dataset_dict1.to_json(path)
+    dataset_dict2.to_json(path, mode="w")
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0].startswith("Dataset serialization directory")
+    assert caplog.messages[0].endswith("already exists, removing it to overwrite existing files.")
+
+    dataset_dict_from_json = DatasetDict.from_json(
+        data_dir=str(path),
+    )
+    assert set(dataset_dict_from_json) == set(dataset_dict2)
+    for split in dataset_dict:
+        assert len(dataset_dict_from_json[split]) == len(dataset_dict2[split])
+        for doc1, doc2 in zip(dataset_dict_from_json[split], dataset_dict2[split]):
             assert doc1 == doc2
 
 


### PR DESCRIPTION
from the docstring:
```
mode: mode for writing the data. Can be either "a" (append) or "w" (overwrite). Default is "a".
```

We use `"a"` as default to be backwards compatible. This should be adjusted to `"w"` in the next breaking release. 

partly implements #158