### PR TITLE
use `TextBasedDocument` instead of `TextDocument` in tests

### DIFF
--- a/tests/fixtures/builder/datasets/default_config_kwargs/default_config_kwargs.py
+++ b/tests/fixtures/builder/datasets/default_config_kwargs/default_config_kwargs.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import datasets
 from pie_modules.annotations import LabeledSpan
 from pie_core import AnnotationLayer, annotation_field
-from pie_modules.documents import TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder
 from tests import FIXTURES_ROOT
@@ -23,7 +23,7 @@ class ExampleConfig(datasets.BuilderConfig):
 
 
 @dataclass
-class ExampleDocument(TextDocument):
+class ExampleDocument(TextBasedDocument):
     entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 

--- a/tests/fixtures/builder/datasets/multi_config/multi_config.py
+++ b/tests/fixtures/builder/datasets/multi_config/multi_config.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import datasets
 from pie_modules.annotations import LabeledSpan
 from pie_core import AnnotationLayer, annotation_field
-from pie_modules.documents import TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder
 from tests import FIXTURES_ROOT
@@ -23,7 +23,7 @@ class ExampleConfig(datasets.BuilderConfig):
 
 
 @dataclass
-class ExampleDocument(TextDocument):
+class ExampleDocument(TextBasedDocument):
     entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 

--- a/tests/fixtures/builder/datasets/name_mapping/name_mapping.py
+++ b/tests/fixtures/builder/datasets/name_mapping/name_mapping.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import datasets
 from pie_modules.annotations import LabeledSpan
 from pie_core import AnnotationLayer, annotation_field
-from pie_modules.documents import TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder
 from tests import FIXTURES_ROOT
@@ -23,7 +23,7 @@ class ExampleConfig(datasets.BuilderConfig):
 
 
 @dataclass
-class ExampleDocument(TextDocument):
+class ExampleDocument(TextBasedDocument):
     entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 

--- a/tests/fixtures/builder/datasets/name_mapping_disabled/name_mapping_disabled.py
+++ b/tests/fixtures/builder/datasets/name_mapping_disabled/name_mapping_disabled.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import datasets
 from pie_modules.annotations import LabeledSpan
 from pie_core import AnnotationLayer, annotation_field
-from pie_modules.documents import TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder
 from tests import FIXTURES_ROOT
@@ -23,7 +23,7 @@ class ExampleConfig(datasets.BuilderConfig):
 
 
 @dataclass
-class ExampleDocument(TextDocument):
+class ExampleDocument(TextBasedDocument):
     entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 

--- a/tests/fixtures/builder/datasets/single_config/single_config.py
+++ b/tests/fixtures/builder/datasets/single_config/single_config.py
@@ -4,7 +4,7 @@ from typing import Type
 import datasets
 from pie_modules.annotations import LabeledSpan
 from pie_core import AnnotationLayer, annotation_field
-from pie_modules.documents import TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import GeneratorBasedBuilder
 from tests import FIXTURES_ROOT
@@ -24,7 +24,7 @@ class ExampleConfig(datasets.BuilderConfig):
 
 
 @dataclass
-class ExampleDocument(TextDocument):
+class ExampleDocument(TextBasedDocument):
     entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 

--- a/tests/fixtures/builder/datasets/wrong_builder_class_config/wrong_builder_class_config.py
+++ b/tests/fixtures/builder/datasets/wrong_builder_class_config/wrong_builder_class_config.py
@@ -4,7 +4,7 @@ from typing import Type
 import datasets
 from pie_modules.annotations import LabeledSpan
 from pie_core import AnnotationLayer, annotation_field
-from pie_modules.documents import TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import ArrowBasedBuilder
 from tests import FIXTURES_ROOT
@@ -24,7 +24,7 @@ class ExampleConfig(datasets.BuilderConfig):
 
 
 @dataclass
-class ExampleDocument(TextDocument):
+class ExampleDocument(TextBasedDocument):
     entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 

--- a/tests/unit/core/test_dataset_dict.py
+++ b/tests/unit/core/test_dataset_dict.py
@@ -5,9 +5,18 @@ from typing import Dict, Iterable, Optional, Union
 
 import datasets
 import pytest
-from pie_core import AnnotationLayer, Document, WithDocumentTypeMixin, annotation_field
+from pie_core import (
+    AnnotationLayer,
+    Document,
+    EnterDatasetDictMixin,
+    EnterDatasetMixin,
+    ExitDatasetDictMixin,
+    ExitDatasetMixin,
+    WithDocumentTypeMixin,
+    annotation_field,
+)
 from pie_modules.annotations import Label, LabeledSpan
-from pie_modules.documents import TextBasedDocument, TextDocument
+from pie_modules.documents import TextBasedDocument
 
 from pie_datasets import (
     Dataset,
@@ -15,12 +24,6 @@ from pie_datasets import (
     IterableDataset,
     concatenate_dataset_dicts,
     load_dataset,
-)
-from pie_datasets.core.dataset_dict import (
-    EnterDatasetDictMixin,
-    EnterDatasetMixin,
-    ExitDatasetDictMixin,
-    ExitDatasetMixin,
 )
 from tests import DATASET_BUILDERS_ROOT, FIXTURES_ROOT
 from tests.conftest import CREATE_FIXTURE_DATA, TestDocument
@@ -610,7 +613,7 @@ def test_cast_document_type(dataset_dict):
 
 
 @dataclass
-class TestDocumentWithLabel(TextDocument):
+class TestDocumentWithLabel(TextBasedDocument):
     label: AnnotationLayer[Label] = annotation_field()
 
 


### PR DESCRIPTION
since `TextDocument` is deprecated