### PR TITLE
pin `fsspec` to `<2023.9.0`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2487,4 +2487,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "f91703bdd371944b9c9e15ecc35203ec20f786d1aa066e0d3491b3f5c975f701"
+content-hash = "09fe6b06e5a3b2fb4f63dadc67446b08c6c5efeae34dfba5fea7015ef3153e68"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ huggingface-hub = ">=0.24.0"
 numpy = "<2.0.0"
 # this was manually added because we get a conflict with pyarrow otherwise
 pyarrow = "^13"
+# pin to version below 2023.9.0 because that one causes problems when using load_dataset with local files (e.g. json)
+fsspec = "<2023.9.0"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
implements #197, also see https://github.com/ArneBinder/pytorch-ie/issues/489

follow-up: when `pytorch-ie` is not used anymore (#178 + `pie-modules` release including https://github.com/ArneBinder/pie-modules/pull/187 for tests), check if this is really still necessary