### PR TITLE
implement `(Iterable)Dataset.map_to_hf()`

### DIFF
--- a/src/pie_datasets/core/builder.py
+++ b/src/pie_datasets/core/builder.py
@@ -9,7 +9,7 @@ from .dataset import (
     Dataset,
     DocumentConvertersType,
     IterableDataset,
-    decorate_convert_to_dict_of_lists,
+    decorate_convert_document_back,
     get_pie_dataset_type,
 )
 
@@ -190,7 +190,7 @@ class PieDatasetBuilder(datasets.builder.DatasetBuilder):
                 f"the builder has no DOCUMENT_TYPE or DOCUMENT_TYPES[{self.config.name}] defined"
             )
 
-        fn = decorate_convert_to_dict_of_lists(self._generate_document)
+        fn = decorate_convert_document_back(self._generate_document)
         fn_kwargs = self._generate_document_kwargs(dataset)
         mapped_dataset = dataset.map(fn, fn_kwargs=fn_kwargs)
         dataset_type = get_pie_dataset_type(mapped_dataset)

--- a/src/pie_datasets/core/dataset.py
+++ b/src/pie_datasets/core/dataset.py
@@ -372,7 +372,7 @@ class Dataset(datasets.Dataset, Sequence[D]):
         """Map the dataset using a function and return a Huggingface Dataset.
 
         Args:
-            function (Optional[Callable], optional): The function to apply to each document. Defaults to None.
+            function (Optional[Callable], optional): The function to apply to the documents. Defaults to None.
             as_documents (bool, optional): Whether the function returns documents. Defaults to True.
             **map_kwargs: Additional keyword arguments for the Huggingface Dataset.map method.
         """
@@ -612,7 +612,7 @@ class IterableDataset(datasets.IterableDataset):
         """Map the dataset using a function and return a Huggingface IterableDataset.
 
         Args:
-            function (Optional[Callable], optional): The function to apply to each document. Defaults to None.
+            function (Optional[Callable], optional): The function to apply to the documents. Defaults to None.
             as_documents (bool, optional): Whether the function returns documents. Defaults to True.
             batched (bool, optional): Whether to apply the function in batches. Defaults to False.
             **map_kwargs: Additional keyword arguments for the Huggingface IterableDataset.map method.

--- a/src/pie_datasets/core/dataset.py
+++ b/src/pie_datasets/core/dataset.py
@@ -38,10 +38,17 @@ def decorate_convert_document_back(f):
 
     @wraps(f)
     def decorated(item, *args, **kwargs):
-        if isinstance(item, list):
-            return list_of_dicts2dict_of_lists([e.asdict() for e in f(item, *args, **kwargs)])
+        doc_or_docs = f(item, *args, **kwargs)
+        if isinstance(doc_or_docs, Document):
+            return doc_or_docs.asdict()
+        elif isinstance(doc_or_docs, list):
+            # if the result is a list, we assume that the output is a list of Documents
+            # and convert it to a dict of lists
+            return list_of_dicts2dict_of_lists([e.asdict() for e in doc_or_docs])
         else:
-            return f(item, *args, **kwargs).asdict()
+            raise TypeError(
+                f"The function {f} should return a Document or a list of Documents, but returned {type(doc_or_docs)}"
+            )
 
     return decorated
 

--- a/src/pie_datasets/core/dataset.py
+++ b/src/pie_datasets/core/dataset.py
@@ -62,12 +62,10 @@ def decorate_convert_to_document(f, document_type: Type[Document], batched: bool
     @wraps(f)
     def decorated(item, *args, **kwargs):
         if batched:
-            return [
-                document_type.fromdict(x)
-                for x in f(dict_of_lists2list_of_dicts(item), *args, **kwargs)
-            ]
+            items = dict_of_lists2list_of_dicts(item)
+            return f([document_type.fromdict(e) for e in items], *args, **kwargs)
         else:
-            return document_type.fromdict(item)
+            return f(document_type.fromdict(item), *args, **kwargs)
 
     return decorated
 

--- a/src/pie_datasets/core/dataset.py
+++ b/src/pie_datasets/core/dataset.py
@@ -372,7 +372,7 @@ class Dataset(datasets.Dataset, Sequence[D]):
         """Map the dataset using a function and return a Huggingface Dataset.
 
         Args:
-            function (Optional[Callable], optional): The function to apply to each example. Defaults to None.
+            function (Optional[Callable], optional): The function to apply to each document. Defaults to None.
             as_documents (bool, optional): Whether the function returns documents. Defaults to True.
             **map_kwargs: Additional keyword arguments for the Huggingface Dataset.map method.
         """
@@ -612,7 +612,7 @@ class IterableDataset(datasets.IterableDataset):
         """Map the dataset using a function and return a Huggingface IterableDataset.
 
         Args:
-            function (Optional[Callable], optional): The function to apply to each example. Defaults to None.
+            function (Optional[Callable], optional): The function to apply to each document. Defaults to None.
             as_documents (bool, optional): Whether the function returns documents. Defaults to True.
             batched (bool, optional): Whether to apply the function in batches. Defaults to False.
             **map_kwargs: Additional keyword arguments for the Huggingface IterableDataset.map method.

--- a/src/pie_datasets/core/dataset.py
+++ b/src/pie_datasets/core/dataset.py
@@ -634,7 +634,7 @@ class IterableDataset(datasets.IterableDataset):
         result_document_type: Optional[Type[Document]] = None,
         **map_kwargs,
     ) -> "IterableDataset":
-        dataset_mapped = self.map_to_hf(**map_kwargs)
+        dataset_mapped = self.map_to_hf(function=function, **map_kwargs)
 
         if result_document_type is None:
             result_document_type = self.document_type

--- a/src/pie_datasets/core/dataset.py
+++ b/src/pie_datasets/core/dataset.py
@@ -367,13 +367,13 @@ class Dataset(datasets.Dataset, Sequence[D]):
         )
 
     def map_to_hf(
-        self, function: Optional[Callable] = None, as_documents: bool = True, **map_kwargs
+        self, function: Optional[Callable] = None, as_documents: bool = False, **map_kwargs
     ) -> datasets.Dataset:
         """Map the dataset using a function and return a Huggingface Dataset.
 
         Args:
             function (Optional[Callable], optional): The function to apply to the documents. Defaults to None.
-            as_documents (bool, optional): Whether the function returns documents. Defaults to True.
+            as_documents (bool, optional): Whether the function returns documents. Defaults to False.
             **map_kwargs: Additional keyword arguments for the Huggingface Dataset.map method.
         """
         if function is not None and as_documents:
@@ -605,7 +605,7 @@ class IterableDataset(datasets.IterableDataset):
     def map_to_hf(
         self,
         function: Optional[Callable] = None,
-        as_documents: bool = True,
+        as_documents: bool = False,
         batched: bool = False,
         **map_kwargs,
     ) -> datasets.IterableDataset:
@@ -613,7 +613,7 @@ class IterableDataset(datasets.IterableDataset):
 
         Args:
             function (Optional[Callable], optional): The function to apply to the documents. Defaults to None.
-            as_documents (bool, optional): Whether the function returns documents. Defaults to True.
+            as_documents (bool, optional): Whether the function returns documents. Defaults to False.
             batched (bool, optional): Whether to apply the function in batches. Defaults to False.
             **map_kwargs: Additional keyword arguments for the Huggingface IterableDataset.map method.
         """
@@ -631,10 +631,11 @@ class IterableDataset(datasets.IterableDataset):
     def map(  # type: ignore
         self,
         function: Optional[Callable] = None,
+        as_documents: bool = True,
         result_document_type: Optional[Type[Document]] = None,
         **map_kwargs,
     ) -> "IterableDataset":
-        dataset_mapped = self.map_to_hf(function=function, **map_kwargs)
+        dataset_mapped = self.map_to_hf(function=function, as_documents=as_documents, **map_kwargs)
 
         if result_document_type is None:
             result_document_type = self.document_type

--- a/tests/unit/core/test_dataset.py
+++ b/tests/unit/core/test_dataset.py
@@ -80,6 +80,29 @@ def test_dataset_map_batched(maybe_iterable_dataset):
     assert sum(len(doc.relations) for doc in train_dataset) == 7
 
 
+def test_empty_dataset_map(maybe_iterable_empty_dataset):
+    train_dataset = maybe_iterable_empty_dataset["train"]
+    assert train_dataset.document_type is TestDocument
+
+    def clear_relations(document):
+        document.relations.clear()
+        return document
+
+    mapped_dataset = train_dataset.map(clear_relations)
+    assert mapped_dataset.document_type is TestDocument
+
+
+def test_empty_dataset_map_batched(maybe_iterable_empty_dataset):
+    train_dataset = maybe_iterable_empty_dataset["train"]
+    assert train_dataset.document_type is TestDocument
+
+    def clear_relations_batched(documents):
+        return documents
+
+    mapped_dataset = train_dataset.map(clear_relations_batched, batched=True, batch_size=2)
+    assert mapped_dataset.document_type is TestDocument
+
+
 def test_dataset_map_with_result_document_type(maybe_iterable_dataset):
     @dataclass
     class TestDocument(TextBasedDocument):


### PR DESCRIPTION
This PR implements `(Iterable)Dataset.map_to_hf()` and use it in `.map()` (from where it was outsourced):
```
Map the (iterable) dataset using a function and return a Huggingface (Iterable)Dataset.

Args:
    function (Optional[Callable], optional): The function to apply to the documents. Defaults to None.
    as_documents (bool, optional): Whether the function returns documents. Defaults to False.
    **map_kwargs: Additional keyword arguments for the Huggingface (Iterable)Dataset.map method.
```

 In addition, it implements the changes below. 

testing:
- add tests for map with empty datasets
- add tests for `as_documents=False`

fixes:
- fix usage of `as_documents` for `IterableDataset.map()`: it now behaves identical as for `Datset.map()`, i.e., it signals "Whether the function returns documents. Defaults to True."

cleanup:
- rename `decorate_convert_to_dict_of_lists` to `decorate_convert_document_back`
- use dict util methods from pie_core instead of pandas DataFrame.to_dict() and local version
- improve documentation

