### PR TITLE
fix: use `pie-datasets 0.10.x` in all dataset scripts

### DIFF
--- a/dataset_builders/pie/aae2/requirements.txt
+++ b/dataset_builders/pie/aae2/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/abstrct/requirements.txt
+++ b/dataset_builders/pie/abstrct/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/argmicro/requirements.txt
+++ b/dataset_builders/pie/argmicro/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/biorel/requirements.txt
+++ b/dataset_builders/pie/biorel/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/brat/requirements.txt
+++ b/dataset_builders/pie/brat/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/cdcp/requirements.txt
+++ b/dataset_builders/pie/cdcp/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/chemprot/requirements.txt
+++ b/dataset_builders/pie/chemprot/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/comagc/requirements.txt
+++ b/dataset_builders/pie/comagc/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/conll2003/requirements.txt
+++ b/dataset_builders/pie/conll2003/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
+++ b/dataset_builders/pie/conll2012_ontonotesv5/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/drugprot/requirements.txt
+++ b/dataset_builders/pie/drugprot/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/imdb/requirements.txt
+++ b/dataset_builders/pie/imdb/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/sciarg/requirements.txt
+++ b/dataset_builders/pie/sciarg/requirements.txt
@@ -1,3 +1,3 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0
 networkx>=3.0.0,<4.0.0

--- a/dataset_builders/pie/scidtb_argmin/requirements.txt
+++ b/dataset_builders/pie/scidtb_argmin/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/scientific_papers/requirements.txt
+++ b/dataset_builders/pie/scientific_papers/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/squad_v2/requirements.txt
+++ b/dataset_builders/pie/squad_v2/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/tacred/requirements.txt
+++ b/dataset_builders/pie/tacred/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0

--- a/dataset_builders/pie/tbga/requirements.txt
+++ b/dataset_builders/pie/tbga/requirements.txt
@@ -1,2 +1,2 @@
-pie-datasets>=0.10.11,<0.12.0
+pie-datasets>=0.10.11,<0.11.0
 pie-modules>=0.15.9,<0.16.0


### PR DESCRIPTION
we unintentionally skipped one version, so this PR decreases the max version to `<0.11.0 `