### PR TITLE
add missing user to `BASE_DATASET_PATH`s

### DIFF
--- a/dataset_builders/pie/conll2003/conll2003.py
+++ b/dataset_builders/pie/conll2003/conll2003.py
@@ -40,7 +40,7 @@ class CoNLL2003Document(TextBasedDocument):
 class Conll2003(GeneratorBasedBuilder):
     DOCUMENT_TYPE = CoNLL2003Document
 
-    BASE_DATASET_PATH = "conll2003"
+    BASE_DATASET_PATH = "eriktks/conll2003"
     BASE_DATASET_REVISION = "01ad4ad271976c5258b9ed9b910469a806ff3288"
 
     BUILDER_CONFIGS = [

--- a/dataset_builders/pie/conll2012_ontonotesv5/conll2012_ontonotesv5.py
+++ b/dataset_builders/pie/conll2012_ontonotesv5/conll2012_ontonotesv5.py
@@ -427,7 +427,7 @@ class Conll2012Ontonotesv5(GeneratorBasedBuilder):
         TextDocumentWithLabeledSpansAndLabeledPartitions: convert_to_text_document_with_labeled_spans_and_labeled_partitions
     }
 
-    BASE_DATASET_PATH = "conll2012_ontonotesv5"
+    BASE_DATASET_PATH = "ontonotes/conll2012_ontonotesv5"
     BASE_DATASET_REVISION = "1161216f7e7185a4b2f4d0a4e0734dc7919dfa15"
 
     BUILDER_CONFIGS = [

--- a/dataset_builders/pie/imdb/imdb.py
+++ b/dataset_builders/pie/imdb/imdb.py
@@ -42,7 +42,7 @@ def document_to_example(document: ImdbDocument, labels: datasets.ClassLabel) -> 
 class Imdb(GeneratorBasedBuilder):
     DOCUMENT_TYPE = ImdbDocument
 
-    BASE_DATASET_PATH = "imdb"
+    BASE_DATASET_PATH = "stanfordnlp/imdb"
     BASE_DATASET_REVISION = "9c6ede893febf99215a29cc7b72992bb1138b06b"
 
     BUILDER_CONFIGS = [

--- a/dataset_builders/pie/scientific_papers/scientific_papers.py
+++ b/dataset_builders/pie/scientific_papers/scientific_papers.py
@@ -76,7 +76,7 @@ class ScientificPapersConfig(datasets.BuilderConfig):
 class ScientificPapers(GeneratorBasedBuilder):
     DOCUMENT_TYPE = ScientificPapersDocument
 
-    BASE_DATASET_PATH = "scientific_papers"
+    BASE_DATASET_PATH = "armanc/scientific_papers"
     BASE_DATASET_REVISION = "14c5296f2d707630f5835c9da59dcaddeea19b20"
 
     BUILDER_CONFIGS = [

--- a/dataset_builders/pie/squad_v2/squad_v2.py
+++ b/dataset_builders/pie/squad_v2/squad_v2.py
@@ -66,7 +66,7 @@ class SquadV2Config(datasets.BuilderConfig):
 class SquadV2(GeneratorBasedBuilder):
     DOCUMENT_TYPE = SquadV2Document
 
-    BASE_DATASET_PATH = "squad_v2"
+    BASE_DATASET_PATH = "rajpurkar/squad_v2"
     BASE_DATASET_REVISION = "e4d7191788b08fde3cbd09bd8fe1fcd827ee1715"
 
     BUILDER_CONFIGS = [


### PR DESCRIPTION
i.e., for formerly "canonical" datasets. The old syntax seems to break for newer `dataset` versions (infinite loops).